### PR TITLE
Turn on memory corruption hardening where available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,4 +8,4 @@ if ENABLE_LIBTLS
 pkgconfig_DATA += libtls.pc
 endif
 
-EXTRA_DIST = VERSION config
+EXTRA_DIST = VERSION config scripts

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 AC_MSG_RESULT([$CLANG])
 AS_IF([test "x$CLANG" == "xyes"], [CLANG_FLAGS=-Qunused-arguments])
 
-# We want to check for compiler flag support, but there is no way to make
+# We want to check for compiler flag support. Prior to clang v5.1, there was no way to make
 # clang's "argument unused" warning fatal.  So we invoke the compiler through a
 # wrapper script that greps for this message.
 saved_CC="$CC"

--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 	[CLANG=yes],
 	[CLANG=no]
 )
-AC_MSG_RESULT([CLANG])
+AC_MSG_RESULT([$CLANG])
 AS_IF([test "x$CLANG" == "xyes"], [CLANG_FLAGS=-Qunused-arguments])
 
 # We want to check for compiler flag support, but there is no way to make

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,68 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
 )
 AC_MSG_RESULT([CLANG])
 
+# We want to check for compiler flag support, but there is no way to make
+# clang's "argument unused" warning fatal.  So we invoke the compiler through a
+# wrapper script that greps for this message.
+saved_CC="$CC"
+saved_LD="$LD"
+flag_wrap="$srcdir/scripts/wrap-compiler-for-flag-check"
+CC="$flag_wrap $CC"
+LD="$flag_wrap $LD"
+
+AC_DEFUN([check_cflag],
+	[AX_CHECK_COMPILE_FLAG([$1], [$2], [$3], [-Werror $4])])
+AC_DEFUN([check_ldflag],
+	[AX_CHECK_LINK_FLAG([$1], [$2], [$3], [-Werror $4])])
+
+
+AC_ARG_ENABLE([hardening],
+	[AS_HELP_STRING([--disable-hardening], [Disable options to frustrate memory corruption exploits])],
+	[],
+	[enable_hardening=yes])
+
+HARDEN_CFLAGS=""
+HARDEN_LDFLAGS=""
+AS_IF([test "x$enable_hardening" == "xyes"], [
+	# Tell GCC to NOT optimize based on signed arithmetic overflow
+	check_cflag([-fno-strict-overflow], [HARDEN_CFLAGS="$HARDEN_CFLAGS -fno-strict-overflow"])
+
+	# _FORTIFY_SOURCE replaces builtin functions with safer versions.
+	check_cflag([-D_FORTIFY_SOURCE=2], 
+		[HARDEN_CFLAGS="$HARDEN_CFLAGS -D_FORTIFY_SOURCE=2"])
+
+	# Use stack-protector-strong if available; if not, fallback to stack-protector-all which
+	# is considered to be overkill
+	check_cflag([-fstack-protector-strong], 
+		[STACK_PROTECT="-fstack-protector-strong"],
+		check_cflag([-fstack-protector-all],
+			[STACK_PROTECT="-fstack-protector-all"],
+			[AC_MSG_ERROR([compiler does not support stack protection - use --disable-hardening to override if you understand the risks])]
+		)
+	)
+
+	check_ldflag([$STACK_PROTECT],
+		[HARDEN_CFLAGS="$HARDEN_CFLAGS $STACK_PROTECT"
+		 check_cflag([-Wstack-protector], [HARDEN_CFLAGS="$HARDEN_CFLAGS -Wstack-protector"],
+		 	[], [$STACK_PROTECT])
+		],
+		[AC_MSG_ERROR([compiler supports stack protection but linker does not])]
+	)
+
+	# Enable read only relocations
+	check_ldflag([-Wl,-z,relro],
+   		[HARDEN_LDFLAGS="$HARDEN_LDFLAGS -Wl,-z,relro"
+    	check_ldflag([-Wl,-z,now], [HARDEN_LDFLAGS="$HARDEN_LDFLAGS -Wl,-z,now"])])
+])
+
+# Restore CC, LD
+CC="$saved_CC"
+LD="$saved_LD"
+
+CFLAGS="$CFLAGS $HARDEN_CFLAGS"
+LDFLAGS="$LDFLAGS $HARDEN_LDFLAGS"
+
+# Removing the dependency on -Wno-pointer-sign should be a goal
 save_cflags="$CFLAGS"
 CFLAGS=-Wno-pointer-sign
 AC_MSG_CHECKING([whether CC supports -Wno-pointer-sign])

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,17 @@ AC_PROG_LIBTOOL
 AC_PROG_CC_STDC
 AM_PROG_CC_C_O
 
+AC_MSG_CHECKING([if compiling with clang])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#ifndef __clang__
+	not clang
+#endif
+	]])],
+	[CLANG=yes],
+	[CLANG=no]
+)
+AC_MSG_RESULT([CLANG])
+
 save_cflags="$CFLAGS"
 CFLAGS=-Wno-pointer-sign
 AC_MSG_CHECKING([whether CC supports -Wno-pointer-sign])
@@ -73,16 +84,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 )
 CFLAGS="$save_cflags $AM_CFLAGS"
 
-AC_MSG_CHECKING([if compiling with clang])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
-#ifndef __clang__
-	not clang
-#endif
-	]])],
-	[AC_MSG_RESULT([yes])]
-	[CLANG_FLAGS=-Qunused-arguments],
-	[AC_MSG_RESULT([no])]
-)
+# TODO: note CFLAGS=...CLANG_CFLAGS has no effect since the latter is undefined
+# investigate its effect
+AS_IF([test "x$CLANG" == "xyes"], [CLANG_FLAGS=-Qunused-arguments])
 CFLAGS="$CFLAGS $CLANG_CFLAGS"
 LDFLAGS="$LDFLAGS $CLANG_FLAGS"
 

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.59)dnl for _AC_LANG_PREFIX
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,73 @@
+# ===========================================================================
+#    http://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/scripts/wrap-compiler-for-flag-check
+++ b/scripts/wrap-compiler-for-flag-check
@@ -3,12 +3,16 @@
 # From kmcallister: 
 # https://github.com/kmcallister/autoharden/blob/efaf5a16612589808c276a11536ea9a47071f74b/scripts/wrap-compiler-for-flag-check
 
-# There is no way to make clang's "argument unused" warning fatal.  So when
-# configure checks for supported flags, it runs $CC, $CXX, $LD via this
-# wrapper.
+# Prior to clang v5.1, there was no way to make
+# clang's "argument unused" warning fatal.  This
+# wrapper script that greps for this warning message. Newer clang's have no issues.
 #
 # Ideally the search string would also include 'clang: ' but this output might
 # depend on clang's argv[0].
+#
+# This file is in the public domain.
+set -o errexit
+set -o nounset
 
 if out=`"$@" 2>&1`; then
   echo "$out"

--- a/scripts/wrap-compiler-for-flag-check
+++ b/scripts/wrap-compiler-for-flag-check
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# From kmcallister: 
+# https://github.com/kmcallister/autoharden/blob/efaf5a16612589808c276a11536ea9a47071f74b/scripts/wrap-compiler-for-flag-check
+
+# There is no way to make clang's "argument unused" warning fatal.  So when
+# configure checks for supported flags, it runs $CC, $CXX, $LD via this
+# wrapper.
+#
+# Ideally the search string would also include 'clang: ' but this output might
+# depend on clang's argv[0].
+
+if out=`"$@" 2>&1`; then
+  echo "$out"
+  if echo "$out" | grep 'warning: argument unused' >/dev/null; then
+    echo "$0: found clang warning"
+    exit 1
+  else
+    exit 0
+  fi
+else
+  code=$?
+  echo "$out"
+  exit $code
+fi


### PR DESCRIPTION
Many compilers enable some kind of hardening by default, but this is not universally the case, and some more aggressive options are not always enabled.

There may be a performance impact to -fstack-protector-all by default, but Chromium uses this option when -fstack-protector-strong is not available, and I think that is appropriate for a critical security component.