### PR TITLE
Add preliminary Cygwin support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,9 @@ AC_SUBST([USER_CFLAGS], "-O2 $CFLAGS")
 CFLAGS="$CFLAGS -Wall -std=gnu99 -g"
 
 case $host_os in
+	*cygwin*)
+		HOST_OS=cygwin
+		;;
 	*darwin*)
 		HOST_OS=darwin
 		HOST_ABI=macosx
@@ -53,6 +56,7 @@ case $host_os in
 	*) ;;
 esac
 
+AM_CONDITIONAL([HOST_CYGWIN],  [test x$HOST_OS = xcygwin])
 AM_CONDITIONAL([HOST_DARWIN],  [test x$HOST_OS = xdarwin])
 AM_CONDITIONAL([HOST_FREEBSD], [test x$HOST_OS = xfreebsd])
 AM_CONDITIONAL([HOST_HPUX],    [test x$HOST_OS = xhpux])
@@ -163,7 +167,7 @@ AS_IF([test "x$enable_hardening" = "xyes"], [
 				AC_MSG_WARN([compiler does not appear to support stack protection])
 			)
 		)
-		AS_IF([test "x$HOST_OS" = "xwin"], [
+		AS_IF([test "x$HOST_OS" = "xwin" -o "x$HOST_OS" = "xcygwin"], [
 			AC_SEARCH_LIBS([__stack_chk_guard],[ssp])
 		])
 	])

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AS_IF([test "x$enable_hardening" = "xyes"], [
 				AC_MSG_WARN([compiler does not appear to support stack protection])
 			)
 		)
-		AS_IF([test "x$HOST_OS" = "xwin" -o "x$HOST_OS" = "xcygwin"], [
+		AS_IF([test "x$HOST_OS" = "xwin"], [
 			AC_SEARCH_LIBS([__stack_chk_guard],[ssp])
 		])
 	])


### PR DESCRIPTION
Hi,

I'd like to add support for Cygwin to libressl portable, slowly and
carefully.  For a start I'd like to propose the below patch.  It allows
to build with the default hardening without having to specify
--enable-windows-ssp.  Other than that change, libressl-portable builds
out of the box on Cygwin 1.7.35, the upcoming release later this week. 
The reason it needs 1.7.35 is the existence of the issetugid function.
The functionality existed for a long time, it was just never exported so far.

Unfortunately the testsuite doesn't build on Cygwin, because the testsuite
requires SA_ONSTACK and sigaltstack to work, functionality not available
yet on Cygwin.  But that's another issue.

Thanks,
Corinna

Signed-off-by: Corinna Vinschen <github@cygwin.de>