### PR TITLE
Reuse _OPENBSD_SOURCE namespace on NetBSD (>=8.x)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ case $host_os in
 		;;
 	*netbsd*)
 		HOST_OS=netbsd
+		CFLAGS="$CFLAGS -D_OPENBSD_SOURCE"
 		;;
 	*openbsd*)
 		HOST_ABI=elf


### PR DESCRIPTION
It enables (for now) the system-wide reallocarray(3) and strtonum(3).