### PR TITLE
install a default openssl.cnf

### DIFF
--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -84,4 +84,24 @@ noinst_HEADERS += s_apps.h
 noinst_HEADERS += testdsa.h
 noinst_HEADERS += testrsa.h
 noinst_HEADERS += timeouts.h
-noinst_HEADERS += openssl.cnf
+
+EXTRA_DIST = cert.pem
+EXTRA_DIST += openssl.cnf
+EXTRA_DIST += x509v3.cnf
+
+install-exec-hook:
+	@mkdir -p "$(DESTDIR)/$(OPENSSLDIR)"
+	@for i in cert.pem openssl.cnf x509v3.cnf; do \
+		if [ ! -f "$(DESTDIR)/$(OPENSSLDIR)/$i" ]; then \
+			$(INSTALL) -m 644 "$(srcdir)/$$i" "$(DESTDIR)/$(OPENSSLDIR)/$$i"; \
+		else \
+			echo " $(DESTDIR)/$(OPENSSLDIR)/$$i already exists, install will not overwrite"; \
+		fi \
+	done
+
+uninstall-local:
+	@for i in cert.pem openssl.cnf x509v3.cnf; do \
+		if cmp -s "$(DESTDIR)/$(OPENSSLDIR)/$$i" "$(srcdir)/$$i"; then \
+			rm -f "$(DESTDIR)/$(OPENSSLDIR)/$$i"; \
+		fi \
+	done

--- a/configure.ac
+++ b/configure.ac
@@ -57,8 +57,11 @@ AC_CHECK_HEADERS([err.h])
 AC_ARG_WITH([openssldir],
 	AS_HELP_STRING([--with-openssldir],
 		       [Set the default openssl directory]),
-	AC_DEFINE_UNQUOTED(OPENSSLDIR, "$withval")
+	OPENSSLDIR="$withval",
+	OPENSSLDIR="$sysconfdir/ssl"
 )
+AC_SUBST(OPENSSLDIR)
+AC_DEFINE_UNQUOTED(OPENSSLDIR, "$OPENSSLDIR")
 
 AC_ARG_ENABLE([extratests],
 	AS_HELP_STRING([--enable-extratests], [Enable extra tests that may be unreliable on some platforms]))

--- a/update.sh
+++ b/update.sh
@@ -203,7 +203,9 @@ sed -e "s/compat\///" crypto/Makefile.am.arc4random > \
 # copy openssl(1) source
 echo "copying openssl(1) source"
 $CP $libc_src/stdlib/strtonum.c apps
+$CP $libcrypto_src/cert.pem apps
 $CP $libcrypto_src/openssl.cnf apps
+$CP $libcrypto_src/x509v3.cnf apps
 for i in `awk '/SOURCES|HEADERS/ { print $3 }' apps/Makefile.am` ; do
 	if [ -e $openssl_app_src/$i ]; then
 		$CP $openssl_app_src/$i apps


### PR DESCRIPTION
This is a work-in-progress patch to automatically install an openssl.cnf file into OPENSSLDIR, which itself will default to sysconfdir to simplify packaging.

This should also probably modify openssl.1 to point to the right path on install.