### PR TITLE
add include/compat/readpassphrase.h to Makefile.am

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -10,6 +10,7 @@ noinst_HEADERS += compat/dirent_msvc.h
 noinst_HEADERS += compat/err.h
 noinst_HEADERS += compat/netdb.h
 noinst_HEADERS += compat/poll.h
+noinst_HEADERS += compat/readpassphrase.h
 noinst_HEADERS += compat/stdio.h
 noinst_HEADERS += compat/stdlib.h
 noinst_HEADERS += compat/string.h


### PR DESCRIPTION
fix for https://github.com/libressl-portable/portable/issues/138