### PR TITLE
wrap gets(3) on Windows, replacing '\r\n' with '\n'

### DIFF
--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -38,6 +38,20 @@ posix_fopen(const char *path, const char *mode)
 	return fopen(path, mode);
 }
 
+char *
+posix_fgets(char *s, int size, FILE *stream)
+{
+	char *ret = fgets(s, size, stream);
+	if (ret != NULL) {
+		size_t end = strlen(ret);
+		if (end >= 2 && ret[end - 2] == '\r' && ret[end - 1] == '\n') {
+			ret[end - 2] = '\n';
+			ret[end - 1] = '\0';
+		}
+	}
+	return ret;
+}
+
 int
 posix_rename(const char *oldpath, const char *newpath)
 {

--- a/include/compat/stdio.h
+++ b/include/compat/stdio.h
@@ -28,11 +28,13 @@ int asprintf(char **str, const char *fmt, ...);
 
 void posix_perror(const char *s);
 FILE * posix_fopen(const char *path, const char *mode);
+char * posix_fgets(char *s, int size, FILE *stream);
 int posix_rename(const char *oldpath, const char *newpath);
 
 #ifndef NO_REDEF_POSIX_FUNCTIONS
 #define perror(errnum) posix_perror(errnum)
 #define fopen(path, mode) posix_fopen(path, mode)
+#define fgets(s, size, stream) posix_fgets(s, size, stream)
 #define rename(oldpath, newpath) posix_rename(oldpath, newpath)
 #endif
 


### PR DESCRIPTION
The gets(3) implementation on Windows includes the trailing characters '\r\n' in the returned stream, but the string handling code in openssl(1) generally expects '\n'.

This fixes #159, but unfortunately means that additionally things like password prompts had been including the '\r' in the resulting passwords when they got processed as well.