### PR TITLE
Replace STDIN_FILENO with _fileno

### DIFF
--- a/crypto/compat/ui_openssl_win.c
+++ b/crypto/compat/ui_openssl_win.c
@@ -301,7 +301,7 @@ open_console(UI *ui)
 	tty_in = stdin;
 	tty_out = stderr;
 
-	HANDLE handle = (HANDLE)_get_osfhandle(STDIN_FILENO);
+	HANDLE handle = (HANDLE)_get_osfhandle(_fileno(stdin));
 	if (handle != INVALID_HANDLE_VALUE) {
 		if (GetFileType(handle) == FILE_TYPE_CHAR)
 			return GetConsoleMode(handle, &console_mode);
@@ -314,7 +314,7 @@ open_console(UI *ui)
 static int
 noecho_console(UI *ui)
 {
-	HANDLE handle = (HANDLE)_get_osfhandle(STDIN_FILENO);
+	HANDLE handle = (HANDLE)_get_osfhandle(_fileno(stdin));
 	if (handle != INVALID_HANDLE_VALUE) {
 		if (GetFileType(handle) == FILE_TYPE_CHAR)
 			return SetConsoleMode(handle, console_mode & ~ENABLE_ECHO_INPUT);
@@ -327,7 +327,7 @@ noecho_console(UI *ui)
 static int
 echo_console(UI *ui)
 {
-	HANDLE handle = (HANDLE)_get_osfhandle(STDIN_FILENO);
+	HANDLE handle = (HANDLE)_get_osfhandle(_fileno(stdin));
 	if (handle != INVALID_HANDLE_VALUE) {
 		if (GetFileType(handle) == FILE_TYPE_CHAR)
 			return SetConsoleMode(handle, console_mode);


### PR DESCRIPTION
Replace STDIN_FILENO with _fileno as STDIN_FILENO results in compile
errors with Visual Studio 2015 (using CMake).