### PR TITLE
build failed on HP-UX 11iv3 (11.31) for undefined u_long in netinet/ip.h

### DIFF
--- a/include/compat/netinet/ip.h
+++ b/include/compat/netinet/ip.h
@@ -3,6 +3,10 @@
  * netinet/ip.h compatibility shim
  */
 
+#if defined(__hpux)
+#include <netinet/in_systm.h>
+#endif
+
 #ifndef _WIN32
 #include_next <netinet/ip.h>
 #else


### PR DESCRIPTION
Hi,
I had this build error on HP-UX 11iv3 (11.31) with GCC 4.7.1 and HP C/aC++ A.06.25, both.
<pre>
...
  CC       netcat.o
"/usr/include/netinet/ip.h", line 123: error #2020: identifier "n_long" is
          undefined
                n_long  ipt_time[1];
                ^
"/usr/include/netinet/ip.h", line 126: error #2020: identifier "n_long" is
          undefined
                        n_long ipt_time;
                        ^
2 errors detected in the compilation of "netcat.c".
*** Error exit code 2
</pre>

`n_long` is defined in `netinet/in_systm.h` on HP-UX 11iv3.
Could you add including <netinet/in_systm.h> in include/compat/netinet/ip.h ?

Thanks.