### PR TITLE
set cmake_minimum_required to 2.8.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ include(CheckFunctionExists)
 include(CheckLibraryExists)
 include(CheckIncludeFiles)
 
-project (LibreSSL)
+project (LibreSSL C)
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.8)
 include(CheckFunctionExists)
 include(CheckLibraryExists)
 include(CheckIncludeFiles)


### PR DESCRIPTION
`OBJECT` library type of add_library was introduced by CMake 2.8.8.