### PR TITLE
execute tests that require srcdir environment variable with cmake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,11 +12,10 @@ include_directories(
 set(ENV{srcdir} ${CMAKE_CURRENT_SOURCE_DIR})
 
 # aeadtest
-#add_executable(aeadtest aeadtest.c)
-#target_link_libraries(aeadtest ${OPENSSL_LIBS})
-#add_test(aeadtest aeadtest.sh)
-#configure_file(aeadtests.txt aeadtests.txt COPYONLY)
-#configure_file(aeadtest.sh aeadtest.sh COPYONLY)
+add_executable(aeadtest aeadtest.c)
+target_link_libraries(aeadtest ${OPENSSL_LIBS})
+add_test(aeadtest ${CMAKE_CURRENT_SOURCE_DIR}/aeadtest.sh)
+set_tests_properties(aeadtest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # aes_wrap
 add_executable(aes_wrap aes_wrap.c)
@@ -127,9 +126,10 @@ target_link_libraries(enginetest ${OPENSSL_LIBS})
 add_test(enginetest enginetest)
 
 # evptest
-#add_executable(evptest evptest.c)
-#target_link_libraries(evptest ${OPENSSL_LIBS})
-#add_test(evptest ${CMAKE_CURRENT_SOURCE_DIR}/evptest.sh)
+add_executable(evptest evptest.c)
+target_link_libraries(evptest ${OPENSSL_LIBS})
+add_test(evptest ${CMAKE_CURRENT_SOURCE_DIR}/evptest.sh)
+set_tests_properties(evptest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # explicit_bzero
 # explicit_bzero relies on SA_ONSTACK, which is unavailable on Windows
@@ -208,9 +208,10 @@ target_link_libraries(poly1305test ${OPENSSL_LIBS})
 add_test(poly1305test poly1305test)
 
 # pq_test
-#add_executable(pq_test pq_test.c)
-#target_link_libraries(pq_test ${OPENSSL_LIBS})
-#add_test(pq_test ${CMAKE_CURRENT_SOURCE_DIR}/pq_test.sh)
+add_executable(pq_test pq_test.c)
+target_link_libraries(pq_test ${OPENSSL_LIBS})
+add_test(pq_test ${CMAKE_CURRENT_SOURCE_DIR}/pq_test.sh)
+set_tests_properties(pq_test PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # randtest
 add_executable(randtest randtest.c)
@@ -253,18 +254,22 @@ target_link_libraries(sha512test ${OPENSSL_LIBS})
 add_test(sha512test sha512test)
 
 # ssltest
-#add_executable(ssltest ssltest.c)
-#target_link_libraries(ssltest ${OPENSSL_LIBS})
-#add_test(ssltest ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
+add_executable(ssltest ssltest.c)
+target_link_libraries(ssltest ${OPENSSL_LIBS})
+add_test(ssltest ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
+set_tests_properties(ssltest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # testdsa
-#add_test(testdsa ${CMAKE_CURRENT_SOURCE_DIR}/testdsa.sh)
+add_test(testdsa ${CMAKE_CURRENT_SOURCE_DIR}/testdsa.sh)
+set_tests_properties(testdsa PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # testenc
 add_test(testenc ${CMAKE_CURRENT_SOURCE_DIR}/testenc.sh)
+set_tests_properties(testenc PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # testrsa
-#add_test(testrsa ${CMAKE_CURRENT_SOURCE_DIR}/testrsa.sh)
+add_test(testrsa ${CMAKE_CURRENT_SOURCE_DIR}/testrsa.sh)
+set_tests_properties(testrsa PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 
 # timingsafe
 add_executable(timingsafe timingsafe.c)

--- a/tests/ssltest.sh
+++ b/tests/ssltest.sh
@@ -6,9 +6,16 @@ if [ -e ./ssltest.exe ]; then
 	ssltest_bin=./ssltest.exe
 fi
 
-openssl_bin=../apps/openssl/openssl
-if [ -e ../apps/openssl/openssl.exe ]; then
-	openssl_bin=../apps/openssl/openssl.exe
+if [ -d ../apps/openssl ]; then
+	openssl_bin=../apps/openssl/openssl
+	if [ -e ../apps/openssl/openssl.exe ]; then
+		openssl_bin=../apps/openssl/openssl.exe
+	fi
+else
+	openssl_bin=../apps/openssl
+	if [ -e ../apps/openssl.exe ]; then
+		openssl_bin=../apps/openssl.exe
+	fi
 fi
 
 if [ -z $srcdir ]; then

--- a/tests/testdsa.sh
+++ b/tests/testdsa.sh
@@ -4,9 +4,16 @@
 
 #Test DSA certificate generation of openssl
 
-cmd=../apps/openssl/openssl
-if [ -e ../apps/openssl/openssl.exe ]; then
-	cmd=../apps/openssl/openssl.exe
+if [ -d ../apps/openssl ]; then
+	cmd=../apps/openssl/openssl
+	if [ -e ../apps/openssl/openssl.exe ]; then
+		cmd=../apps/openssl/openssl.exe
+	fi
+else
+	cmd=../apps/openssl
+	if [ -e ../apps/openssl.exe ]; then
+		cmd=../apps/openssl.exe
+	fi
 fi
 
 if [ -z $srcdir ]; then

--- a/tests/testenc.sh
+++ b/tests/testenc.sh
@@ -2,12 +2,23 @@
 #	$OpenBSD: testenc.sh,v 1.1 2014/08/26 17:50:07 jsing Exp $
 
 test=p
-cmd=../apps/openssl/openssl
-if [ -e ../apps/openssl/openssl.exe ]; then
-	cmd=../apps/openssl/openssl.exe
+if [ -d ../apps/openssl ]; then
+	cmd=../apps/openssl/openssl
+	if [ -e ../apps/openssl/openssl.exe ]; then
+		cmd=../apps/openssl/openssl.exe
+	fi
+else
+	cmd=../apps/openssl
+	if [ -e ../apps/openssl.exe ]; then
+		cmd=../apps/openssl.exe
+	fi
 fi
 
-cat openssl.cnf >$test;
+if [ -z $srcdir ]; then
+	srcdir=.
+fi
+
+cat $srcdir/openssl.cnf >$test;
 
 echo cat
 $cmd enc < $test > $test.cipher

--- a/tests/testrsa.sh
+++ b/tests/testrsa.sh
@@ -4,9 +4,16 @@
 
 #Test RSA certificate generation of openssl
 
-cmd=../apps/openssl/openssl
-if [ -e ../apps/openssl/openssl.exe ]; then
-	cmd=../apps/openssl/openssl.exe
+if [ -d ../apps/openssl ]; then
+	cmd=../apps/openssl/openssl
+	if [ -e ../apps/openssl/openssl.exe ]; then
+		cmd=../apps/openssl/openssl.exe
+	fi
+else
+	cmd=../apps/openssl
+	if [ -e ../apps/openssl.exe ]; then
+		cmd=../apps/openssl.exe
+	fi
 fi
 
 if [ -z $srcdir ]; then


### PR DESCRIPTION
- uncomment procedures for aeadtest, evptest, pq_test, ssltest, testdsa and testrsa
- add set_tests_properties() for setting environment variable srcdir
- tweak openssl path in ssltest.sh, testdsa.sh, testenc.sh and testrsa.sh