### PR TITLE
add cmake build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ string(STRIP ${TLS_VERSION} TLS_VERSION)
 string(REPLACE ":" "." TLS_VERSION ${TLS_VERSION})
 string(REGEX REPLACE "\\..*" "" TLS_MAJOR_VERSION ${TLS_VERSION})
 
+option(ENABLE_ASM "Enable assembly" ON)
+option(ENABLE_EXTRATESTS "Enable extra tests that may be unreliable on some platforms" OFF)
+option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
+set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
+
+set(BUILD_NC true)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+	add_definitions(-fno-common)
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 	add_definitions(-DHAVE_ATTRIBUTE__BOUNDED__)
 endif()
@@ -32,6 +43,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_definitions(-D_BSD_SOURCE)
 	add_definitions(-D_POSIX_SOURCE)
 	add_definitions(-D_GNU_SOURCE)
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "MINGW")
+	set(BUILD_NC false)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "HP-UX")

--- a/apps/nc/CMakeLists.txt
+++ b/apps/nc/CMakeLists.txt
@@ -43,6 +43,12 @@ else()
 	set(NC_SRC ${NC_SRC} compat/strtonum.c)
 endif()
 
+if(NOT "${OPENSSLDIR}" STREQUAL "")
+	add_definitions(-DDEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+else()
+	add_definitions(-DDEFAULT_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
+endif()
+
 add_executable(nc ${NC_SRC})
 target_link_libraries(nc tls ${OPENSSL_LIBS})
 

--- a/apps/openssl/CMakeLists.txt
+++ b/apps/openssl/CMakeLists.txt
@@ -79,3 +79,11 @@ target_link_libraries(openssl ${OPENSSL_LIBS})
 
 install(TARGETS openssl DESTINATION bin)
 install(FILES openssl.1 DESTINATION share/man/man1)
+
+if(NOT "${OPENSSLDIR}" STREQUAL "")
+	set(CONF_DIR "${OPENSSLDIR}")
+else()
+	set(CONF_DIR "${CMAKE_INSTALL_PREFIX}/etc/ssl")
+endif()
+install(FILES cert.pem openssl.cnf x509v3.cnf DESTINATION ${CONF_DIR})
+install(DIRECTORY DESTINATION ${CONF_DIR}/cert)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -742,6 +742,12 @@ else()
 	endif()
 endif()
 
+if(NOT "${OPENSSLDIR}" STREQUAL "")
+	add_definitions(-DOPENSSLDIR=\"${OPENSSLDIR}\")
+else()
+	add_definitions(-DOPENSSLDIR=\"${CMAKE_INSTALL_PREFIX}/etc/ssl\")
+endif()
+
 if (BUILD_SHARED)
 	add_library(crypto-objects OBJECT ${CRYPTO_SRC})
 	add_library(crypto STATIC $<TARGET_OBJECTS:crypto-objects>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,6 @@ include_directories(
 	../apps/openssl/compat
 )
 
-set(ENV{srcdir} ${CMAKE_CURRENT_SOURCE_DIR})
-
 # aeadtest
 add_executable(aeadtest aeadtest.c)
 target_link_libraries(aeadtest ${OPENSSL_LIBS})
@@ -24,7 +22,7 @@ add_test(aes_wrap aes_wrap)
 
 # arc4randomforktest
 # Windows/mingw does not have fork, but Cygwin does.
-if(NOT CMAKE_HOST_WIN32)
+if(NOT CMAKE_HOST_WIN32 AND NOT CMAKE_SYSTEM_NAME MATCHES "MINGW")
 add_executable(arc4randomforktest arc4randomforktest.c)
 target_link_libraries(arc4randomforktest ${OPENSSL_LIBS})
 add_test(arc4randomforktest ${CMAKE_CURRENT_SOURCE_DIR}/arc4randomforktest.sh)
@@ -49,6 +47,14 @@ add_test(base64test base64test)
 add_executable(bftest bftest.c)
 target_link_libraries(bftest ${OPENSSL_LIBS})
 add_test(bftest bftest)
+
+# biotest
+# the BIO tests rely on resolver results that are OS and environment-specific
+if(ENABLE_EXTRATESTS)
+	add_executable(biotest biotest.c)
+	target_link_libraries(biotest ${OPENSSL_LIBS})
+	add_test(biotest biotest)
+endif()
 
 # bntest
 add_executable(bntest bntest.c)
@@ -197,6 +203,15 @@ add_test(optionstest optionstest)
 add_executable(pbkdf2 pbkdf2.c)
 target_link_libraries(pbkdf2 ${OPENSSL_LIBS})
 add_test(pbkdf2 pbkdf2)
+
+# pidwraptest
+# pidwraptest relies on an OS-specific way to give out pids and is generally
+# awkward on systems with slow fork
+if(ENABLE_EXTRATESTS)
+	add_executable(pidwraptest pidwraptest.c)
+	target_link_libraries(pidwraptest ${OPENSSL_LIBS})
+	add_test(pidwraptest ${CMAKE_CURRENT_SOURCE_DIR}/pidwraptest.sh)
+endif()
 
 # pkcs7test
 add_executable(pkcs7test pkcs7test.c)

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -21,6 +21,12 @@ if(NOT HAVE_STRSEP)
 	set(TLS_SRC ${TLS_SRC} strsep.c)
 endif()
 
+if(NOT "${OPENSSLDIR}" STREQUAL "")
+	add_definitions(-D_PATH_SSL_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+else()
+	add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
+endif()
+
 if (BUILD_SHARED)
 	add_library(tls-objects OBJECT ${TLS_SRC})
 	add_library(tls STATIC $<TARGET_OBJECTS:tls-objects>)


### PR DESCRIPTION
- add cmake build options as configure provides
  * -DENABLE_ASM (default ON)
  * -DENABLE_EXTRATESTS (default OFF)
  * -DENABLE_NC (default OFF)
  * -DOPENSSLDIR (default ${CMAKE_INSTALL_PREFIX}/etc/ssl)

- add biotest and pidwraptest if ENABLE_EXTRATESTS is ON