### PR TITLE
fix ld warning "attempted multiple inclusion of file" on Solaris

### DIFF
--- a/apps/nc/Makefile.am
+++ b/apps/nc/Makefile.am
@@ -12,9 +12,9 @@ EXTRA_DIST = nc.1
 EXTRA_DIST += CMakeLists.txt
 
 nc_LDADD = $(PLATFORM_LDADD) $(PROG_LDADD)
-nc_LDADD += $(top_builddir)/crypto/libcrypto.la
-nc_LDADD += $(top_builddir)/ssl/libssl.la
-nc_LDADD += $(top_builddir)/tls/libtls.la
+nc_LDADD += $(abs_top_builddir)/crypto/libcrypto.la
+nc_LDADD += $(abs_top_builddir)/ssl/libssl.la
+nc_LDADD += $(abs_top_builddir)/tls/libtls.la
 
 AM_CPPFLAGS += -I$(top_srcdir)/apps/nc/compat
 if OPENSSLDIR_DEFINED

--- a/apps/openssl/Makefile.am
+++ b/apps/openssl/Makefile.am
@@ -5,8 +5,8 @@ bin_PROGRAMS = openssl
 dist_man_MANS = openssl.1
 
 openssl_LDADD = $(PLATFORM_LDADD) $(PROG_LDADD)
-openssl_LDADD += $(top_builddir)/ssl/libssl.la
-openssl_LDADD += $(top_builddir)/crypto/libcrypto.la
+openssl_LDADD += $(abs_top_builddir)/ssl/libssl.la
+openssl_LDADD += $(abs_top_builddir)/crypto/libcrypto.la
 
 openssl_SOURCES = apps.c
 openssl_SOURCES += asn1pars.c

--- a/ssl/Makefile.am
+++ b/ssl/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 
 libssl_la_LDFLAGS = -version-info @LIBSSL_VERSION@ -no-undefined
-libssl_la_LIBADD = ../crypto/libcrypto.la
+libssl_la_LIBADD = $(abs_top_builddir)/crypto/libcrypto.la
 
 libssl_la_SOURCES = bio_ssl.c
 libssl_la_SOURCES += bs_ber.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,9 +7,9 @@ AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
 
 LDADD = $(PLATFORM_LDADD) $(PROG_LDADD)
-LDADD += $(top_builddir)/ssl/libssl.la
-LDADD += $(top_builddir)/crypto/libcrypto.la
-LDADD += $(top_builddir)/tls/libtls.la
+LDADD += $(abs_top_builddir)/ssl/libssl.la
+LDADD += $(abs_top_builddir)/crypto/libcrypto.la
+LDADD += $(abs_top_builddir)/tls/libtls.la
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -6,7 +6,9 @@ EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 
 libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined
-libtls_la_LIBADD = ../crypto/libcrypto.la ../ssl/libssl.la $(PLATFORM_LDADD)
+libtls_la_LIBADD = $(abs_top_builddir)/ssl/libssl.la
+libtls_la_LIBADD += $(abs_top_builddir)/crypto/libcrypto.la
+libtls_la_LIBADD += $(PLATFORM_LDADD)
 
 libtls_la_CPPFLAGS = $(AM_CPPFLAGS)
 if OPENSSLDIR_DEFINED


### PR DESCRIPTION
- To avoid ld warning on Solaris, use abs_top_builddir in Makefile.am

On Solaris11.3(i386) I'm getting ld warning "attempted multiple inclusion of file" like below.
<pre>
...
  CCLD   openssl
ld: warning: file ../../crypto/.libs/libcrypto.so: linked to /work/github/libressl-2.4.0/crypto/.libs/libcrypto.so: attempted multiple inclusion of file
...
</pre>
This warning comes from Solaris ld can't tell `../../crypto/.libs/libcrypto.so` and `/work/github/libressl-2.4.0/crypto/.libs/libcrypto.so` are the same library.

openssl is defined that it should be linked with $(top_builddir)/ssl/libssl.la and $(top_builddir)/crypto/libcrypto.la in apps/openssl/Makefile.am .
And libtool seems try to link libraries at dependency_libs in .la files, too.

In ssl/libssl.la, libcrypto.la is described as absolute path at dependency_libs, like this.
<pre>
...
# Libraries that this one depends upon.
dependency_libs=' /work/github/libressl-2.4.0/crypto/libcrypto.la -lnsl -lsocket -lresolv'
...
</pre>
Then absolute path libcrypto and relative path libcrypto bring "attempted multiple inclusion of file".

To avoid this ld warnings, I would like to suggest using `abs_top_builddir` instead of `top_builddir` in Makefile.am.

Regards,