### PR TITLE
pc: add platform-specific libs to Libs.private

### DIFF
--- a/libcrypto.pc.in
+++ b/libcrypto.pc.in
@@ -11,5 +11,5 @@ Version: @VERSION@
 Requires:
 Conflicts:
 Libs: -L${libdir} -lcrypto
-Libs.private: @LIBS@
+Libs.private: @LIBS@ @PLATFORM_LDADD@
 Cflags: -I${includedir}

--- a/libssl.pc.in
+++ b/libssl.pc.in
@@ -12,5 +12,5 @@ Requires:
 Requires.private: libcrypto
 Conflicts:
 Libs: -L${libdir} -lssl
-Libs.private: @LIBS@ -lcrypto
+Libs.private: @LIBS@ -lcrypto @PLATFORM_LDADD@
 Cflags: -I${includedir}

--- a/libtls.pc.in
+++ b/libtls.pc.in
@@ -12,5 +12,5 @@ Requires:
 Requires.private: libcrypto libssl
 Conflicts:
 Libs: -L${libdir} -ltls
-Libs.private: @LIBS@ -lcrypto -lssl
+Libs.private: @LIBS@ -lcrypto -lssl @PLATFORM_LDADD@
 Cflags: -I${includedir}


### PR DESCRIPTION
Fixes compilations including libressl static libraries in MinGW.

Signed-off-by: Ricardo Constantino (:RiCON) <wiiaboo@gmail.com>