### PR TITLE
Fix typo in USE_BUILTIN_ARC4RANDOM check

### DIFF
--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -59,7 +59,7 @@ AM_CONDITIONAL([HAVE_TIMINGSAFE_MEMCMP], [test "x$ac_cv_func_timingsafe_memcmp" 
 
 # Override arc4random_buf implementations with known issues
 AM_CONDITIONAL([HAVE_ARC4RANDOM_BUF],
-	[test "x$USE_BUILTIN_ARC4RANDOM" != yes \
+	[test "x$USE_BUILTIN_ARC4RANDOM" != xyes \
 	   -a "x$ac_cv_func_arc4random_buf" = xyes])
 
 # Check for getentropy fallback dependencies


### PR DESCRIPTION
Solaris 11 recently introduced a builtin arc4random in libc which fails the tests in "make check". Found USE_BUILTIN_ARC4RANDOM, but could not get it to work. Apparently, there is a typo in the configure logic rendering USE_BUILTIN_ARC4RANDOM ineffective.