### PR TITLE
Set _PATH_SSL_CA_FILE for the OCSP tests in the cmake build system

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,11 @@ add_test(mont mont)
 
 # ocsp_test
 if(ENABLE_EXTRATESTS)
+	if(NOT "${OPENSSLDIR}" STREQUAL "")
+		add_definitions(-D_PATH_SSL_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+	else()
+		add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
+	endif()
 	add_executable(ocsp_test ocsp_test.c)
 	target_link_libraries(ocsp_test ${OPENSSL_LIBS})
 	add_test(ocsptest ${CMAKE_CURRENT_SOURCE_DIR}/ocsptest.sh)


### PR DESCRIPTION
Currently on cmake builds, make test shows the OCSP tests as failing if /etc/ssl/cert.pem does not exist. This change to CMakeLists.txt defines _PATH_SSL_CA_FILE to a sane value if either OPENSSLDIR or CMAKE_INSTALL_PREFIX is set so that these tests can run successfully without a system-installed libressl.