### PR TITLE
Set _PATH_SSL_CA_FILE to the tarball internal path for regression tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,8 @@ include_directories(
 	../apps/openssl/compat
 )
 
+add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/cert.pem\")
+
 # aeadtest
 add_executable(aeadtest aeadtest.c)
 target_link_libraries(aeadtest ${OPENSSL_LIBS})
@@ -196,15 +198,9 @@ add_test(mont mont)
 
 # ocsp_test
 if(ENABLE_EXTRATESTS)
-	if(NOT "${OPENSSLDIR}" STREQUAL "")
-		add_definitions(-D_PATH_SSL_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
-	else()
-		add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
-	endif()
 	add_executable(ocsp_test ocsp_test.c)
 	target_link_libraries(ocsp_test ${OPENSSL_LIBS})
 	add_test(ocsptest ${CMAKE_CURRENT_SOURCE_DIR}/ocsptest.sh)
-	set_tests_properties(ocsptest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 # optionstest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS += -I $(top_srcdir)/crypto/asn1
 AM_CPPFLAGS += -I $(top_srcdir)/ssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
+AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/apps/openssl/cert.pem\"
 
 LDADD = $(PLATFORM_LDADD) $(PROG_LDADD)
 LDADD += $(abs_top_builddir)/ssl/libssl.la


### PR DESCRIPTION
- let tests to use the cert.pem in the tarball, for both automake and cmake.
- put this definition out of "if(ENABLE_EXTRATESTS)" since this can be shared by all tests.

As discussions in the PR https://github.com/libressl-portable/portable/pull/213 .