### PR TITLE
enable tls_ext_alpn regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ tests/gost2814789t*
 tests/mont*
 tests/rfc5280time*
 tests/timingsafe*
+tests/tls_ext_alpn*
 tests/*test
 tests/tests.h
 tests/*test.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -305,6 +305,11 @@ add_executable(timingsafe timingsafe.c)
 target_link_libraries(timingsafe ${OPENSSL_LIBS})
 add_test(timingsafe timingsafe)
 
+# tls_ext_alpn
+add_executable(tls_ext_alpn tls_ext_alpn.c)
+target_link_libraries(tls_ext_alpn ${OPENSSL_LIBS})
+add_test(tls_ext_alpn tls_ext_alpn)
+
 # utf8test
 add_executable(utf8test utf8test.c)
 target_link_libraries(utf8test ${OPENSSL_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -324,6 +324,11 @@ TESTS += timingsafe
 check_PROGRAMS += timingsafe
 timingsafe_SOURCES = timingsafe.c
 
+# tls_ext_alpn
+TESTS += tls_ext_alpn
+check_PROGRAMS += tls_ext_alpn
+tls_ext_alpn_SOURCES = tls_ext_alpn.c
+
 # utf8test
 TESTS += utf8test
 check_PROGRAMS += utf8test


### PR DESCRIPTION
- add tls_ext_alpn entry for automake and cmake
- add tests/tls_ext_alpn* to .gitignore