### PR TITLE
Fix the rest of the current build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ endif()
 
 add_definitions(-DLIBRESSL_INTERNAL)
 add_definitions(-DOPENSSL_NO_HW_PADLOCK)
+add_definitions(-D__BEGIN_HIDDEN_DECLS=)
+add_definitions(-D__END_HIDDEN_DECLS=)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE true)
 

--- a/Makefile.am.common
+++ b/Makefile.am.common
@@ -1,2 +1,3 @@
 AM_CFLAGS =
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/compat -DLIBRESSL_INTERNAL
+AM_CPPFLAGS += -D__BEGIN_HIDDEN_DECLS= -D__END_HIDDEN_DECLS=

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -463,7 +463,6 @@ set(
 	idea/i_ecb.c
 	idea/i_ofb64.c
 	idea/i_skey.c
-	krb5/krb5_asn.c
 	lhash/lh_stats.c
 	lhash/lhash.c
 	md4/md4_dgst.c

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -11,24 +11,24 @@ include_directories(
 if(HOST_ASM_ELF_X86_64)
 	set(
 		ASM_X86_64_ELF_SRC
-		aes/aes-elf-x86_64.s
-		aes/bsaes-elf-x86_64.s
-		aes/vpaes-elf-x86_64.s
-		aes/aesni-elf-x86_64.s
-		aes/aesni-sha1-elf-x86_64.s
-		bn/modexp512-elf-x86_64.s
-		bn/mont-elf-x86_64.s
-		bn/mont5-elf-x86_64.s
-		bn/gf2m-elf-x86_64.s
-		camellia/cmll-elf-x86_64.s
-		md5/md5-elf-x86_64.s
-		modes/ghash-elf-x86_64.s
-		rc4/rc4-elf-x86_64.s
-		rc4/rc4-md5-elf-x86_64.s
-		sha/sha1-elf-x86_64.s
+		aes/aes-elf-x86_64.S
+		aes/bsaes-elf-x86_64.S
+		aes/vpaes-elf-x86_64.S
+		aes/aesni-elf-x86_64.S
+		aes/aesni-sha1-elf-x86_64.S
+		bn/modexp512-elf-x86_64.S
+		bn/mont-elf-x86_64.S
+		bn/mont5-elf-x86_64.S
+		bn/gf2m-elf-x86_64.S
+		camellia/cmll-elf-x86_64.S
+		md5/md5-elf-x86_64.S
+		modes/ghash-elf-x86_64.S
+		rc4/rc4-elf-x86_64.S
+		rc4/rc4-md5-elf-x86_64.S
+		sha/sha1-elf-x86_64.S
 		sha/sha256-elf-x86_64.S
 		sha/sha512-elf-x86_64.S
-		whrlpool/wp-elf-x86_64.s
+		whrlpool/wp-elf-x86_64.S
 		cpuid-elf-x86_64.S
 	)
 	add_definitions(-DAES_ASM)
@@ -53,24 +53,24 @@ endif()
 if(HOST_ASM_MACOSX_X86_64)
 	set(
 		ASM_X86_64_MACOSX_SRC
-		aes/aes-macosx-x86_64.s
-		aes/bsaes-macosx-x86_64.s
-		aes/vpaes-macosx-x86_64.s
-		aes/aesni-macosx-x86_64.s
-		aes/aesni-sha1-macosx-x86_64.s
-		bn/modexp512-macosx-x86_64.s
-		bn/mont-macosx-x86_64.s
-		bn/mont5-macosx-x86_64.s
-		bn/gf2m-macosx-x86_64.s
-		camellia/cmll-macosx-x86_64.s
-		md5/md5-macosx-x86_64.s
-		modes/ghash-macosx-x86_64.s
-		rc4/rc4-macosx-x86_64.s
-		rc4/rc4-md5-macosx-x86_64.s
-		sha/sha1-macosx-x86_64.s
+		aes/aes-macosx-x86_64.S
+		aes/bsaes-macosx-x86_64.S
+		aes/vpaes-macosx-x86_64.S
+		aes/aesni-macosx-x86_64.S
+		aes/aesni-sha1-macosx-x86_64.S
+		bn/modexp512-macosx-x86_64.S
+		bn/mont-macosx-x86_64.S
+		bn/mont5-macosx-x86_64.S
+		bn/gf2m-macosx-x86_64.S
+		camellia/cmll-macosx-x86_64.S
+		md5/md5-macosx-x86_64.S
+		modes/ghash-macosx-x86_64.S
+		rc4/rc4-macosx-x86_64.S
+		rc4/rc4-md5-macosx-x86_64.S
+		sha/sha1-macosx-x86_64.S
 		sha/sha256-macosx-x86_64.S
 		sha/sha512-macosx-x86_64.S
-		whrlpool/wp-macosx-x86_64.s
+		whrlpool/wp-macosx-x86_64.S
 		cpuid-macosx-x86_64.S
 	)
 	add_definitions(-DAES_ASM)


### PR DESCRIPTION
This fixes the remaining assembly preprocessor and hidden symbol fallout with cmake and autotools builds.