### PR TITLE
configure: fix getentropy() for sierra and ios

### DIFF
--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -17,18 +17,43 @@ case $host_os in
 	*darwin*)
 		HOST_OS=darwin
 		HOST_ABI=macosx
+		#
+		# Don't use arc4random on systems before 10.12 because of
 		# weak seed on failure to open /dev/random, based on latest
 		# public source:
 		# http://www.opensource.apple.com/source/Libc/Libc-997.90.3/gen/FreeBSD/arc4random.c
+		#
+		# We use the presence of getentropy() to detect 10.12. The
+		# following check take into account that:
+ 		#
+		#   - iOS <= 10.1 fails because of missing getentropy and
+		#     hence they miss sys/random.h
+		#
+		#   - in macOS 10.12 getentropy is not tagged as introduced in
+		#     10.12 so we cannot use it for target < 10.12
+		#
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <AvailabilityMacros.h>
 #include <unistd.h>
-#include <sys/random.h>
+#include <sys/random.h>  /* Systems without getentropy() should die here */
+
+/* Based on: https://gitweb.torproject.org/tor.git/commit/?id=16fcbd21 */
+#ifndef MAC_OS_X_VERSION_10_12
+#  define MAC_OS_X_VERSION_10_12 101200
+#endif
+#if defined(MAC_OS_X_VERSION_MIN_REQUIRED)
+#  if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+#    error "Running on Mac OSX 10.11 or earlier"
+#  endif
+#endif
                        ]], [[
 char buf[1]; getentropy(buf, 1);
 					   ]])],
                        [ USE_BUILTIN_ARC4RANDOM=no ],
                        [ USE_BUILTIN_ARC4RANDOM=yes ]
 		)
+		AC_MSG_CHECKING([whether to use builtin arc4random])
+		AC_MSG_RESULT([$USE_BUILTIN_ARC4RANDOM])
 		# Not available on iOS
 		AC_CHECK_HEADER([arpa/telnet.h], [], [BUILD_NC=no])
 		;;


### PR DESCRIPTION
This diff changes the logic by which configure detects getentropy() to
ensure that we don't use the system wide getentropy

- with macOS sierra if the deployment target is lower than sierra as
  found by tor developers here

    https://gitweb.torproject.org/tor.git/commit/?id=https://gitweb.torproject.org/tor.git/commit/?id=16fcbd21c963a9a65bf55024680c8323c8b7175d

- with iOS unconditionally because an app linking libressl compiled with
  system wide getentropy has been rejected by the App store as I have
  documented here

    https://github.com/measurement-kit/measurement-kit/pull/994

I think something similar could also affect clock_gettime judging from
tor's patch, but this diff for now doesn't address that.

I do not have macOS < sierra, so I could only verify that configure was
not picking up system wide getentropy by compiling libressl using

    export CFLAGS="-mmacosx-version-min=10.11"

As regards iOS, removing the check for getentropy and recompiling (thus
using libressl builtin getentropy()) was enough to have another iteration
of the app accepted. Otherwise testing should be possible with:

    export LDFLAGS="-arch armv7 -miphoneos-version-min=7.1 -isysroot `xcrun --show-sdk-path --sdk iphoneos`"
    export CPPFLAGS="-arch armv7 -isysroot `xcrun --show-sdk-path --sdk iphoneos`"
    export CFLAGS="-arch armv7 -miphoneos-version-min=7.1 -isysroot `xcrun --show-sdk-path --sdk iphoneos`"

[edit: and by passing `--host=arm-apple-darwin` to configure]

Related ticket: https://github.com/libressl-portable/portable/issues/230