### PR TITLE
enable tlstest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,9 +261,9 @@ if(NOT BUILD_SHARED)
 endif()
 
 if(USE_SHARED)
-	set(OPENSSL_LIBS ssl-shared crypto-shared)
+	set(OPENSSL_LIBS tls-shared ssl-shared crypto-shared)
 else()
-	set(OPENSSL_LIBS ssl crypto)
+	set(OPENSSL_LIBS tls ssl crypto)
 endif()
 
 if(CMAKE_HOST_WIN32)

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -12,6 +12,7 @@
 #include <ws2tcpip.h>
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +38,28 @@ posix_fopen(const char *path, const char *mode)
 	}
 
 	return fopen(path, mode);
+}
+
+int
+posix_open(const char *path, ...)
+{
+	va_list ap;
+	mode_t mode = 0;
+	int flags;
+
+	va_start(ap, path);
+	flags = va_arg(ap, int);
+	if (flags & O_CREAT)
+		mode = va_arg(ap, int);
+	va_end(ap);
+
+	flags |= O_BINARY;
+	if (flags & O_CLOEXEC) {
+		flags &= ~O_CLOEXEC;
+		flags |= O_NOINHERIT;
+	}
+	flags &= ~O_NONBLOCK;
+	return open(path, flags, mode);
 }
 
 char *

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -109,6 +109,9 @@ wsa_errno(int err)
 	case WSAEAFNOSUPPORT:
 		errno = EAFNOSUPPORT;
 		break;
+	case WSAEBADF:
+		errno = EBADF;
+		break;
 	case WSAENETRESET:
 	case WSAENOTCONN:
 	case WSAECONNABORTED:
@@ -135,7 +138,7 @@ posix_close(int fd)
 {
 	if (closesocket(fd) == SOCKET_ERROR) {
 		int err = WSAGetLastError();
-		return err == WSAENOTSOCK ?
+		return (err == WSAENOTSOCK || err == WSAEBADF) ?
 			close(fd) : wsa_errno(err);
 	}
 	return 0;
@@ -147,7 +150,7 @@ posix_read(int fd, void *buf, size_t count)
 	ssize_t rc = recv(fd, buf, count, 0);
 	if (rc == SOCKET_ERROR) {
 		int err = WSAGetLastError();
-		return err == WSAENOTSOCK ?
+		return (err == WSAENOTSOCK || err == WSAEBADF) ?
 			read(fd, buf, count) : wsa_errno(err);
 	}
 	return rc;
@@ -159,7 +162,7 @@ posix_write(int fd, const void *buf, size_t count)
 	ssize_t rc = send(fd, buf, count, 0);
 	if (rc == SOCKET_ERROR) {
 		int err = WSAGetLastError();
-		return err == WSAENOTSOCK ?
+		return (err == WSAENOTSOCK || err == WSAEBADF) ?
 			write(fd, buf, count) : wsa_errno(err);
 	}
 	return rc;

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -44,7 +44,7 @@ int
 posix_open(const char *path, ...)
 {
 	va_list ap;
-	mode_t mode = 0;
+	int mode = 0;
 	int flags;
 
 	va_start(ap, path);

--- a/crypto/crypto_win.list
+++ b/crypto/crypto_win.list
@@ -1,6 +1,7 @@
 arc4random_buf
 asprintf
 explicit_bzero
+inet_pton
 gettimeofday
 posix_close
 posix_connect

--- a/crypto/crypto_win.list
+++ b/crypto/crypto_win.list
@@ -7,6 +7,7 @@ posix_close
 posix_connect
 posix_fgets
 posix_fopen
+posix_open
 posix_read
 posix_rename
 posix_write

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -8,6 +8,7 @@ noinst_HEADERS = pqueue.h
 noinst_HEADERS += compat/dirent.h
 noinst_HEADERS += compat/dirent_msvc.h
 noinst_HEADERS += compat/err.h
+noinst_HEADERS += compat/fcntl.h
 noinst_HEADERS += compat/limits.h
 noinst_HEADERS += compat/netdb.h
 noinst_HEADERS += compat/poll.h

--- a/include/compat/err.h
+++ b/include/compat/err.h
@@ -18,6 +18,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+__declspec(noreturn)
+#else
+__attribute__((noreturn))
+#endif
 static inline void
 err(int eval, const char *fmt, ...)
 {
@@ -34,6 +39,11 @@ err(int eval, const char *fmt, ...)
 	va_end(ap);
 }
 
+#if defined(_MSC_VER)
+__declspec(noreturn)
+#else
+__attribute__((noreturn))
+#endif
 static inline void
 errx(int eval, const char *fmt, ...)
 {

--- a/include/compat/fcntl.h
+++ b/include/compat/fcntl.h
@@ -1,0 +1,32 @@
+/*
+ * Public domain
+ * fcntl.h compatibility shim
+ */
+
+#ifndef _WIN32
+#include_next <fcntl.h>
+#else
+
+#ifdef _MSC_VER
+#if _MSC_VER >= 1900
+#include <../ucrt/fcntl.h>
+#else
+#include <../include/fcntl.h>
+#endif
+#else
+#include_next <fcntl.h>
+#endif
+
+#ifndef O_NONBLOCK
+#define O_NONBLOCK      0x100000
+#endif
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC       0x200000
+#endif
+
+#ifndef FD_CLOEXEC
+#define FD_CLOEXEC      1
+#endif
+
+#endif

--- a/include/compat/fcntl.h
+++ b/include/compat/fcntl.h
@@ -29,4 +29,10 @@
 #define FD_CLOEXEC      1
 #endif
 
+int posix_open(const char *path, ...);
+
+#ifndef NO_REDEF_POSIX_FUNCTIONS
+#define open(path, ...) posix_open(path, __VA_ARGS__)
+#endif
+
 #endif

--- a/include/compat/fcntl.h
+++ b/include/compat/fcntl.h
@@ -29,10 +29,4 @@
 #define FD_CLOEXEC      1
 #endif
 
-int posix_open(const char *path, ...);
-
-#ifndef NO_REDEF_POSIX_FUNCTIONS
-#define open(path, ...) posix_open(path, __VA_ARGS__)
-#endif
-
 #endif

--- a/include/compat/stdio.h
+++ b/include/compat/stdio.h
@@ -26,6 +26,10 @@ int asprintf(char **str, const char *fmt, ...);
 
 #ifdef _WIN32
 
+#if defined(_MSC_VER)
+#define __func__ __FUNCTION__
+#endif
+
 void posix_perror(const char *s);
 FILE * posix_fopen(const char *path, const char *mode);
 char * posix_fgets(char *s, int size, FILE *stream);

--- a/include/compat/sys/socket.h
+++ b/include/compat/sys/socket.h
@@ -8,3 +8,10 @@
 #else
 #include <win32netcompat.h>
 #endif
+
+#if !defined(SOCK_NONBLOCK) || !defined(SOCK_CLOEXEC)
+#define SOCK_CLOEXEC            0x8000  /* set FD_CLOEXEC */
+#define SOCK_NONBLOCK           0x4000  /* set O_NONBLOCK */
+int bsd_socketpair(int domain, int type, int protocol, int socket_vector[2]);
+#define socketpair(d,t,p,sv) bsd_socketpair(d,t,p,sv)
+#endif

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -40,4 +40,8 @@ int getentropy(void *buf, size_t buflen);
 
 #define pledge(request, paths) 0
 
+#ifndef HAVE_PIPE2
+int pipe2(int fildes[2], int flags);
+#endif
+
 #endif

--- a/include/compat/win32netcompat.h
+++ b/include/compat/win32netcompat.h
@@ -26,7 +26,10 @@
 
 int posix_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 
+int posix_open(const char *path, ...);
+
 int posix_close(int fd);
+
 ssize_t posix_read(int fd, void *buf, size_t count);
 
 ssize_t posix_write(int fd, const void *buf, size_t count);
@@ -39,6 +42,7 @@ int posix_setsockopt(int sockfd, int level, int optname,
 
 #ifndef NO_REDEF_POSIX_FUNCTIONS
 #define connect(sockfd, addr, addrlen) posix_connect(sockfd, addr, addrlen)
+#define open(path, ...) posix_open(path, __VA_ARGS__)
 #define close(fd) posix_close(fd)
 #define read(fd, buf, count) posix_read(fd, buf, count)
 #define write(fd, buf, count) posix_write(fd, buf, count)

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -201,6 +201,7 @@ if test "x$HOST_OS" = "xwin" ; then
 	echo posix_perror >> $crypto_p_sym
 	echo posix_fopen >> $crypto_p_sym
 	echo posix_fgets >> $crypto_p_sym
+	echo posix_open >> $crypto_p_sym
 	echo posix_rename >> $crypto_p_sym
 	echo posix_connect >> $crypto_p_sym
 	echo posix_close >> $crypto_p_sym

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -20,10 +20,12 @@ AM_CONDITIONAL([HAVE_TIMEGM], [test "x$ac_cv_func_timegm" = xyes])
 ])
 
 AC_DEFUN([CHECK_SYSCALL_COMPAT], [
-AC_CHECK_FUNCS([accept4 pledge poll])
+AC_CHECK_FUNCS([accept4 pipe2 pledge poll socketpair])
 AM_CONDITIONAL([HAVE_ACCEPT4], [test "x$ac_cv_func_accept4" = xyes])
+AM_CONDITIONAL([HAVE_PIPE2], [test "x$ac_cv_func_pipe2" = xyes])
 AM_CONDITIONAL([HAVE_PLEDGE], [test "x$ac_cv_func_pledge" = xyes])
 AM_CONDITIONAL([HAVE_POLL], [test "x$ac_cv_func_poll" = xyes])
+AM_CONDITIONAL([HAVE_SOCKETPAIR], [test "x$ac_cv_func_socketpair" = xyes])
 ])
 
 AC_DEFUN([CHECK_B64_NTOP], [

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -346,7 +346,16 @@ add_test(timingsafe timingsafe)
 
 # tlstest
 if(NOT CMAKE_HOST_WIN32 AND NOT CMAKE_SYSTEM_NAME MATCHES "MINGW")
-add_executable(tlstest tlstest.c)
+
+set(TLSTEST_SRC tlstest.c)
+check_function_exists(pipe2 HAVE_PIPE2)
+if(HAVE_PIPE2)
+	add_definitions(-DHAVE_PIPE2)
+else()
+	set(TLSTEST_SRC ${TLSTEST_SRC} compat/pipe2.c)
+endif()
+
+add_executable(tlstest ${TLSTEST_SRC})
 target_link_libraries(tlstest ${TESTS_LIBS})
 if(NOT MSVC)
 	add_test(tlstest ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.sh)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ include_directories(
 add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/cert.pem\")
 
 foreach(lib IN LISTS OPENSSL_LIBS)
-	if(${lib} STREQUAL "ssl-shared")
+	if(${lib} STREQUAL "tls-shared")
+		set(TESTS_LIBS ${TESTS_LIBS} tls)
+	elseif(${lib} STREQUAL "ssl-shared")
 		set(TESTS_LIBS ${TESTS_LIBS} ssl)
 	elseif(${lib} STREQUAL "crypto-shared")
 		set(TESTS_LIBS ${TESTS_LIBS} crypto)
@@ -342,6 +344,18 @@ add_executable(timingsafe timingsafe.c)
 target_link_libraries(timingsafe ${TESTS_LIBS})
 add_test(timingsafe timingsafe)
 
+# tlstest
+if(NOT CMAKE_HOST_WIN32 AND NOT CMAKE_SYSTEM_NAME MATCHES "MINGW")
+add_executable(tlstest tlstest.c)
+target_link_libraries(tlstest ${TESTS_LIBS})
+if(NOT MSVC)
+	add_test(tlstest ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.sh)
+else()
+	add_test(tlstest ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.bat)
+endif()
+set_tests_properties(tlstest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
 # tls_ext_alpn
 add_executable(tls_ext_alpn tls_ext_alpn.c)
 target_link_libraries(tls_ext_alpn ${TESTS_LIBS})
@@ -365,6 +379,7 @@ add_test(x25519test x25519test)
 if(ENABLE_VSTEST AND USE_SHARED)
 	add_custom_command(TARGET x25519test POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
+		"$<TARGET_FILE:tls-shared>"
 		"$<TARGET_FILE:ssl-shared>"
 		"$<TARGET_FILE:crypto-shared>"
 		"${CMAKE_CURRENT_BINARY_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -345,8 +345,6 @@ target_link_libraries(timingsafe ${TESTS_LIBS})
 add_test(timingsafe timingsafe)
 
 # tlstest
-if(NOT CMAKE_HOST_WIN32 AND NOT CMAKE_SYSTEM_NAME MATCHES "MINGW")
-
 set(TLSTEST_SRC tlstest.c)
 check_function_exists(pipe2 HAVE_PIPE2)
 if(HAVE_PIPE2)
@@ -363,7 +361,6 @@ else()
 	add_test(tlstest ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.bat)
 endif()
 set_tests_properties(tlstest PROPERTIES ENVIRONMENT "srcdir=${CMAKE_CURRENT_SOURCE_DIR}")
-endif()
 
 # tls_ext_alpn
 add_executable(tls_ext_alpn tls_ext_alpn.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -333,7 +333,6 @@ check_PROGRAMS += timingsafe
 timingsafe_SOURCES = timingsafe.c
 
 # tlstest
-if !HOST_WIN
 TESTS += tlstest.sh
 check_PROGRAMS += tlstest
 tlstest_SOURCES = tlstest.c
@@ -341,7 +340,6 @@ if !HAVE_PIPE2
 tlstest_SOURCES += compat/pipe2.c
 endif
 EXTRA_DIST += tlstest.sh tlstest.bat
-endif
 
 # tls_ext_alpn
 TESTS += tls_ext_alpn

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -337,6 +337,9 @@ if !HOST_WIN
 TESTS += tlstest.sh
 check_PROGRAMS += tlstest
 tlstest_SOURCES = tlstest.c
+if !HAVE_PIPE2
+tlstest_SOURCES += compat/pipe2.c
+endif
 EXTRA_DIST += tlstest.sh tlstest.bat
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -332,6 +332,14 @@ TESTS += timingsafe
 check_PROGRAMS += timingsafe
 timingsafe_SOURCES = timingsafe.c
 
+# tlstest
+if !HOST_WIN
+TESTS += tlstest.sh
+check_PROGRAMS += tlstest
+tlstest_SOURCES = tlstest.c
+EXTRA_DIST += tlstest.sh tlstest.bat
+endif
+
 # tls_ext_alpn
 TESTS += tls_ext_alpn
 check_PROGRAMS += tls_ext_alpn

--- a/tests/compat/pipe2.c
+++ b/tests/compat/pipe2.c
@@ -1,0 +1,56 @@
+/*
+ * Public domain
+ */
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#undef socketpair
+
+static int setfd(int fd, int flag)
+{
+	int flags = fcntl(fd, F_GETFD);
+	flags |= flag;
+	return fcntl(fd, F_SETFD, flags);
+}
+
+static int setfl(int fd, int flag)
+{
+	int flags = fcntl(fd, F_GETFL);
+	flags |= flag;
+	return fcntl(fd, F_SETFL, flags);
+}
+
+int pipe2(int fildes[2], int flags)
+{
+	int rc = pipe(fildes);
+	if (rc == 0) {
+		if (flags & O_NONBLOCK) {
+			setfl(fildes[0], O_NONBLOCK);
+			setfl(fildes[1], O_NONBLOCK);
+		}
+		if (flags & O_CLOEXEC) {
+			setfd(fildes[0], FD_CLOEXEC);
+			setfd(fildes[1], FD_CLOEXEC);
+		}
+	}
+	return rc;
+}
+
+int bsd_socketpair(int domain, int type, int protocol, int socket_vector[2])
+{
+	int flags = type & ~0xf;
+	type &= 0xf;
+	int rc = socketpair(domain, type, protocol, socket_vector);
+	if (rc == 0) {
+		if (flags & SOCK_NONBLOCK) {
+			setfl(socket_vector[0], O_NONBLOCK);
+			setfl(socket_vector[1], O_NONBLOCK);
+		}
+		if (flags & SOCK_CLOEXEC) {
+			setfd(socket_vector[0], FD_CLOEXEC);
+			setfd(socket_vector[1], FD_CLOEXEC);
+		}
+	}
+	return rc;
+}

--- a/tests/compat/pipe2.c
+++ b/tests/compat/pipe2.c
@@ -1,11 +1,109 @@
 /*
  * Public domain
+ *
+ * pipe2/pipe/socketpair emulation
+ * Brent Cook <bcook@openbsd.org>
  */
 
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/socket.h>
+
 #undef socketpair
+
+#ifdef _WIN32
+
+static int setfd(int fd, int flag)
+{
+	int rc = -1;
+	if (flag & FD_CLOEXEC) {
+		HANDLE h = (HANDLE)_get_osfhandle(fd);
+		if (h != NULL)
+			rc = SetHandleInformation(h, HANDLE_FLAG_INHERIT, 0) == 0 ? -1 : 0;
+	}
+	return rc;
+}
+
+static int setfl(int fd, int flag)
+{
+	int rc = -1;
+	if (flag & O_NONBLOCK) {
+		long mode = 1;
+		rc = ioctlsocket(fd, FIONBIO, &mode);
+	}
+	return rc;
+}
+
+int socketpair(int domain, int type, int protocol, int socket_vector[2])
+{
+	if (domain != AF_UNIX || !(type & SOCK_STREAM) || protocol != PF_UNSPEC)
+		return -1;
+
+	socket_vector[0] = -1;
+	socket_vector[1] = -1;
+
+	int listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (listener == -1) {
+		return -1;
+	}
+
+	struct sockaddr_in addr = {
+		.sin_family = AF_INET,
+		.sin_addr.s_addr = htonl(INADDR_LOOPBACK),
+		.sin_port = 0,
+	};
+
+	int yes = 1, e;
+	if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
+			(void *)&yes, sizeof yes) == -1)
+		goto err;
+
+	if (bind(listener, (struct sockaddr *)&addr, sizeof addr) != 0)
+		goto err;
+
+	memset(&addr, 0, sizeof addr);
+	socklen_t addrlen = sizeof addr;
+	if (getsockname(listener, (struct sockaddr *)&addr, &addrlen) != 0)
+		goto err;
+
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_family = AF_INET;
+
+	if (listen(listener, 1) != 0)
+		goto err;
+
+	socket_vector[0] = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, 0);
+	if (socket_vector[0] == -1)
+		goto err;
+
+	if (connect(socket_vector[0], (struct sockaddr *)&addr, sizeof addr) != 0)
+		goto err;
+
+	socket_vector[1] = accept(listener, NULL, NULL);
+	if (socket_vector[1] == -1)
+		goto err;
+
+	closesocket(listener);
+	return 0;
+
+err:
+	e = WSAGetLastError();
+	closesocket(listener);
+	closesocket(socket_vector[0]);
+	closesocket(socket_vector[1]);
+	WSASetLastError(e);
+	socket_vector[0] = -1;
+	socket_vector[1] = -1;
+	return -1;
+}
+
+int pipe(int fildes[2])
+{
+	return socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, PF_UNSPEC, fildes);
+}
+
+#else
 
 static int setfd(int fd, int flag)
 {
@@ -20,18 +118,25 @@ static int setfl(int fd, int flag)
 	flags |= flag;
 	return fcntl(fd, F_SETFL, flags);
 }
+#endif
 
 int pipe2(int fildes[2], int flags)
 {
 	int rc = pipe(fildes);
 	if (rc == 0) {
 		if (flags & O_NONBLOCK) {
-			setfl(fildes[0], O_NONBLOCK);
-			setfl(fildes[1], O_NONBLOCK);
+			rc |= setfl(fildes[0], O_NONBLOCK);
+			rc |= setfl(fildes[1], O_NONBLOCK);
 		}
 		if (flags & O_CLOEXEC) {
-			setfd(fildes[0], FD_CLOEXEC);
-			setfd(fildes[1], FD_CLOEXEC);
+			rc |= setfd(fildes[0], FD_CLOEXEC);
+			rc |= setfd(fildes[1], FD_CLOEXEC);
+		}
+		if (rc != 0) {
+			int e = errno;
+			close(fildes[0]);
+			close(fildes[1]);
+			errno = e;
 		}
 	}
 	return rc;
@@ -44,12 +149,18 @@ int bsd_socketpair(int domain, int type, int protocol, int socket_vector[2])
 	int rc = socketpair(domain, type, protocol, socket_vector);
 	if (rc == 0) {
 		if (flags & SOCK_NONBLOCK) {
-			setfl(socket_vector[0], O_NONBLOCK);
-			setfl(socket_vector[1], O_NONBLOCK);
+			rc |= setfl(socket_vector[0], O_NONBLOCK);
+			rc |= setfl(socket_vector[1], O_NONBLOCK);
 		}
 		if (flags & SOCK_CLOEXEC) {
-			setfd(socket_vector[0], FD_CLOEXEC);
-			setfd(socket_vector[1], FD_CLOEXEC);
+			rc |= setfd(socket_vector[0], FD_CLOEXEC);
+			rc |= setfd(socket_vector[1], FD_CLOEXEC);
+		}
+		if (rc != 0) {
+			int e = errno;
+			close(socket_vector[0]);
+			close(socket_vector[1]);
+			errno = e;
 		}
 	}
 	return rc;

--- a/tests/ssltest.bat
+++ b/tests/ssltest.bat
@@ -14,5 +14,8 @@ if "%srcdir%"=="" (
 
 %srcdir%\testssl.bat %srcdir%\server.pem %srcdir%\server.pem %srcdir%\ca.pem ^
     %ssltest_bin% %openssl_bin%
+if !errorlevel! neq 0 (
+	exit /b 1
+)
 
 endlocal

--- a/tests/tlstest.bat
+++ b/tests/tlstest.bat
@@ -10,5 +10,8 @@ if "%srcdir%"=="" (
 )
 
 %tlstest_bin% %srcdir%\server.pem %srcdir%\server.pem %srcdir%\ca.pem
+if !errorlevel! neq 0 (
+	exit /b 1
+)
 
 endlocal

--- a/tests/tlstest.bat
+++ b/tests/tlstest.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal enabledelayedexpansion
+REM	tlstest.bat
+
+set tlstest_bin=Debug\tlstest.exe
+if not exist %tlstest_bin% exit /b 1
+
+if "%srcdir%"=="" (
+	set srcdir=.
+)
+
+%tlstest_bin% %srcdir%\server.pem %srcdir%\server.pem %srcdir%\ca.pem
+
+endlocal

--- a/tests/tlstest.sh
+++ b/tests/tlstest.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+tlstest_bin=./tlstest
+if [ -e ./tlstest.exe ]; then
+	tlstest_bin=./tlstest.exe
+fi
+
+if [ -z $srcdir ]; then
+	srcdir=.
+fi
+
+$tlstest_bin $srcdir/server.pem $srcdir/server.pem $srcdir/ca.pem


### PR DESCRIPTION
This is disabled for now on Windows for now due to pipe2/socketpair support, but I think it can be emulated without too much issue. Based on @kinichiro 's work on ssltest