### PR TITLE
Move S_IRGRP and S_IROTH from fcntl.h to sys/stat.h

### DIFF
--- a/include/compat/fcntl.h
+++ b/include/compat/fcntl.h
@@ -30,11 +30,3 @@
 #ifndef FD_CLOEXEC
 #define FD_CLOEXEC      1
 #endif
-
-#ifndef S_IRGRP
-#define S_IRGRP         0
-#endif
-
-#ifndef S_IROTH
-#define S_IROTH         0
-#endif

--- a/include/compat/sys/stat.h
+++ b/include/compat/sys/stat.h
@@ -8,6 +8,15 @@
 
 #ifndef _MSC_VER
 #include_next <sys/stat.h>
+
+/* for old MinGW */
+#ifndef S_IRGRP
+#define S_IRGRP         0
+#endif
+#ifndef S_IROTH
+#define S_IROTH         0
+#endif
+
 #else
 
 #include <windows.h>


### PR DESCRIPTION
- S_IRGRP and S_IROTH should be defined in sys/stat.h rather than fcntl.h
- Old MinGW64 on Ubuntu 14.04 appears not to have S_IRGRP and S_IROTH
- MinGW64 has __WIN32 defined but does not have _MSC_VER defined