### PR TITLE
Document 32-bit time_t problem on minw-w64 toolchain and how to avoid it

### DIFF
--- a/README.windows
+++ b/README.windows
@@ -12,7 +12,8 @@ cross compilers on Windows.
 To configure and build LibreSSL for a 32-bit system, use the following
 build steps:
 
- CC=i686-w64-mingw32-gcc ./configure --host=i686-w64-mingw32
+ CC=i686-w64-mingw32-gcc CPPFLAGS=-D__MINGW_USE_VC2005_COMPAT \
+ ./configure --host=i686-w64-mingw32
  make
  make check
 
@@ -21,6 +22,25 @@ For 64-bit builds, use these instead:
  CC=x86_64-w64-mingw32-gcc ./configure --host=x86_64-w64-mingw32
  make
  make check
+
+# Why the -D__MINGW_USE_VC2005_COMPAT flag on 32-bit systems?
+
+An ABI change introduced with Microsoft Visual C++ 2005 (also known as
+Visual C++ 8.0) switched time_t from 32-bit to 64-bit. It is important to
+build LibreSSL with 64-bit time_t whenever possible, because 32-bit time_t
+is unable to represent times past 2038 (this is commonly known as the
+Y2K38 problem).
+
+If LibreSSL is built with 32-bit time_t, when verifying a certificate whose
+expiry date is set past 19 January 2038, it will be unable to tell if the
+certificate has expired or not, and thus take the safe stance and reject it.
+
+In order to avoid this, you need to build LibreSSL (and everything that links
+with it) with the -D__MINGW_USE_VC2005_COMPAT flag. This tells mingw-w64 to
+use the new ABI.
+
+64-bit systems always have a 64-bit time_t and are not affected by this
+problem.
 
 # Using Libressl with Visual Studio
 

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,14 @@ AM_CONDITIONAL([SMALL_TIME_T], [test "$ac_cv_sizeof_time_t" = "4"])
 if test "$ac_cv_sizeof_time_t" = "4"; then
     echo " ** Warning, this system is unable to represent times past 2038"
     echo " ** It will behave incorrectly when handling valid RFC5280 dates"
+
+    if test "$host_os" = "mingw32" ; then
+        echo " **"
+        echo " ** You can solve this by adjusting the build flags in your"
+        echo " ** mingw-w64 toolchain. Refer to README.windows for details."
+    fi
+
+    exit 1
 fi
 
 AC_REQUIRE_AUX_FILE([tap-driver.sh])

--- a/configure.ac
+++ b/configure.ac
@@ -148,8 +148,6 @@ if test "$ac_cv_sizeof_time_t" = "4"; then
         echo " ** You can solve this by adjusting the build flags in your"
         echo " ** mingw-w64 toolchain. Refer to README.windows for details."
     fi
-
-    exit 1
 fi
 
 AC_REQUIRE_AUX_FILE([tap-driver.sh])


### PR DESCRIPTION
Followup from https://github.com/libressl-portable/portable/pull/286
