### PR TITLE
Fix condition of arc4random* and getentropy for Cygwin build

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -736,8 +736,10 @@ endif()
 
 if(NOT HAVE_ARC4RANDOM_BUF)
 	set(CRYPTO_SRC ${CRYPTO_SRC} compat/arc4random.c)
+	set(CRYPTO_SRC ${CRYPTO_SRC} compat/arc4random_uniform.c)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} arc4random)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} arc4random_buf)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} arc4random_uniform)
 
 	if(NOT HAVE_GETENTROPY)
 		if(CMAKE_HOST_WIN32)
@@ -759,11 +761,6 @@ if(NOT HAVE_ARC4RANDOM_BUF)
 		endif()
 		set(EXTRA_EXPORT ${EXTRA_EXPORT} getentropy)
 	endif()
-endif()
-
-if(NOT HAVE_ARC4RANDOM_UNIFORM)
-	set(CRYPTO_SRC ${CRYPTO_SRC} compat/arc4random_uniform.c)
-	set(EXTRA_EXPORT ${EXTRA_EXPORT} arc4random_uniform)
 endif()
 
 if(NOT HAVE_TIMINGSAFE_BCMP)

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -152,14 +152,13 @@ echo "generating $crypto_p_sym ..."
 chmod u+w $srcdir/crypto
 cp $crypto_sym $crypto_p_sym
 chmod u+w $crypto_p_sym
-if test "x$ac_cv_func_arc4random" = "xno" ; then
-	echo arc4random >> $crypto_p_sym
-fi
 if test "x$ac_cv_func_arc4random_buf" = "xno" ; then
+	echo arc4random >> $crypto_p_sym
 	echo arc4random_buf >> $crypto_p_sym
-fi
-if test "x$ac_cv_func_arc4random_uniform" = "xno" ; then
 	echo arc4random_uniform >> $crypto_p_sym
+	if test "x$ac_cv_func_getentropy" = "xno" ; then
+		echo getentropy >> $crypto_p_sym
+	fi
 fi
 if test "x$ac_cv_func_asprintf" = "xno" ; then
 	echo asprintf >> $crypto_p_sym
@@ -167,9 +166,6 @@ if test "x$ac_cv_func_asprintf" = "xno" ; then
 fi
 if test "x$ac_cv_func_explicit_bzero" = "xno" ; then
 	echo explicit_bzero >> $crypto_p_sym
-fi
-if test "x$ac_cv_func_getentropy" = "xno" ; then
-	echo getentropy >> $crypto_p_sym
 fi
 if test "x$ac_cv_func_inet_pton" = "xno" ; then
 	echo inet_pton >> $crypto_p_sym


### PR DESCRIPTION
- Fix the condition of exporting getentropy
- Modify the CMake condition of including arc4random_uniform as same as autoconf