### PR TITLE
move crypto_portable.sym to builddir

### DIFF
--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -15,7 +15,10 @@ EXTRA_DIST += crypto.sym
 # needed for a CMake target
 EXTRA_DIST += compat/strcasecmp.c
 
-libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols $(top_srcdir)/crypto/crypto_portable.sym
+BUILT_SOURCES = crypto_portable.sym
+CLEANFILES = crypto_portable.sym
+
+libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym
 libcrypto_la_LIBADD = libcompat.la
 if !HAVE_EXPLICIT_BZERO
 libcrypto_la_LIBADD += libcompatnoopt.la

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -150,9 +150,9 @@ fi
 
 AC_DEFUN([GENERATE_CRYPTO_PORTABLE_SYM], [
 crypto_sym=$srcdir/crypto/crypto.sym
-crypto_p_sym=$srcdir/crypto/crypto_portable.sym
+crypto_p_sym=./crypto/crypto_portable.sym
 echo "generating $crypto_p_sym ..."
-chmod u+w $srcdir/crypto
+mkdir -p ./crypto
 cp $crypto_sym $crypto_p_sym
 chmod u+w $crypto_p_sym
 if test "x$ac_cv_func_arc4random_buf" = "xno" ; then


### PR DESCRIPTION
Generated files should be in the builddir rather than the srcdir. Because we're currently generating the file in configure's context, $builddir is not yet available. We should probably actually move the generation process to crypto/Makefile.am as well.

Fixes #300 