### PR TITLE
Fix pkg-config metadata for libcrypto

### DIFF
--- a/libcrypto.pc.in
+++ b/libcrypto.pc.in
@@ -5,8 +5,8 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: LibreSSL-libssl
-Description: Secure Sockets Layer and cryptography libraries
+Name: LibreSSL-libcrypto
+Description: LibreSSL cryptography library
 Version: @VERSION@
 Requires:
 Conflicts:


### PR DESCRIPTION
It looks like this was copied and pasted from libssl.pc.in. This patch
identifies it as libcrypto rather than libssl.