### PR TITLE
Add freezero support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ include/openssl/*.h
 !/crypto/compat/arc4random.h
 !/crypto/compat/b_win.c
 !/crypto/compat/explicit_bzero_win.c
+!/crypto/compat/freezero.c
 !/crypto/compat/getpagesize.c
 !/crypto/compat/posix_win.c
 !/crypto/compat/bsd_asprintf.c

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -681,6 +681,11 @@ if(NOT HAVE_ASPRINTF)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} vasprintf)
 endif()
 
+if(NOT HAVE_FREEZERO)
+	set(CRYPTO_SRC ${CRYPTO_SRC} compat/freezero.c)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} freezero)
+endif()
+
 if(NOT HAVE_GETPAGESIZE)
 	set(CRYPTO_SRC ${CRYPTO_SRC} compat/getpagesize.c)
 endif()

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -84,6 +84,10 @@ if !HAVE_ASPRINTF
 libcompat_la_SOURCES += compat/bsd-asprintf.c
 endif
 
+if !HAVE_FREEZERO
+libcompat_la_SOURCES += compat/freezero.c
+endif
+
 if !HAVE_GETPAGESIZE
 libcompat_la_SOURCES += compat/getpagesize.c
 endif

--- a/crypto/compat/freezero.c
+++ b/crypto/compat/freezero.c
@@ -1,0 +1,13 @@
+#include <string.h>
+#include <stdlib.h>
+
+void
+freezero(void *ptr, size_t sz)
+{
+	/* This is legal. */
+	if (ptr == NULL)
+		return;
+
+	explicit_bzero(ptr, sz);
+	free(ptr);
+}

--- a/include/compat/stdlib.h
+++ b/include/compat/stdlib.h
@@ -25,6 +25,10 @@ void arc4random_buf(void *_buf, size_t n);
 uint32_t arc4random_uniform(uint32_t upper_bound);
 #endif
 
+#ifndef HAVE_FREEZERO
+void freezero(void *ptr, size_t sz);
+#endif
+
 #ifndef HAVE_REALLOCARRAY
 void *reallocarray(void *, size_t, size_t);
 #endif

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -2,11 +2,12 @@ AC_DEFUN([CHECK_LIBC_COMPAT], [
 # Check for libc headers
 AC_CHECK_HEADERS([err.h readpassphrase.h])
 # Check for general libc functions
-AC_CHECK_FUNCS([asprintf getpagesize inet_ntop inet_pton memmem readpassphrase])
-AC_CHECK_FUNCS([reallocarray recallocarray])
+AC_CHECK_FUNCS([asprintf freezero getpagesize inet_ntop inet_pton memmem])
+AC_CHECK_FUNCS([readpassphrase reallocarray recallocarray])
 AC_CHECK_FUNCS([strlcat strlcpy strndup strnlen strsep strtonum])
 AC_CHECK_FUNCS([timegm _mkgmtime])
 AM_CONDITIONAL([HAVE_ASPRINTF], [test "x$ac_cv_func_asprintf" = xyes])
+AM_CONDITIONAL([HAVE_FREEZERO], [test "x$ac_cv_func_freezero" = xyes])
 AM_CONDITIONAL([HAVE_GETPAGESIZE], [test "x$ac_cv_func_getpagesize" = xyes])
 AM_CONDITIONAL([HAVE_INET_NTOP], [test "x$ac_cv_func_inet_ntop" = xyes])
 AM_CONDITIONAL([HAVE_INET_PTON], [test "x$ac_cv_func_inet_pton" = xyes])
@@ -169,6 +170,9 @@ if test "x$ac_cv_func_asprintf" = "xno" ; then
 fi
 if test "x$ac_cv_func_explicit_bzero" = "xno" ; then
 	echo explicit_bzero >> $crypto_p_sym
+fi
+if test "x$ac_cv_func_freezero" = "xno" ; then
+	echo freezero >> $crypto_p_sym
 fi
 if test "x$ac_cv_func_inet_pton" = "xno" ; then
 	echo inet_pton >> $crypto_p_sym


### PR DESCRIPTION
Hi,
This PR provides freezero() for portable.
freezero() is placed in malloc.c in OpenBSD source tree.
I added simple freezero.c bits rather than copying malloc.s from openbsd/src/lib/libc/stdlib/.
Thanks.
