### PR TITLE
Only include ia32 symbols in export list on Intel architectures

### DIFF
--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -150,6 +150,11 @@ fi
 ])
 
 AC_DEFUN([GENERATE_CRYPTO_PORTABLE_SYM], [
+AS_CASE([$host_cpu],
+	[i?86], [HOSTARCH=intel],
+	[x86_64], [HOSTARCH=intel],
+)
+AC_SUBST([HOSTARCH])
 crypto_sym=$srcdir/crypto/crypto.sym
 crypto_p_sym=./crypto/crypto_portable.sym
 echo "generating $crypto_p_sym ..."
@@ -206,6 +211,9 @@ if test "x$ac_cv_func_timingsafe_bcmp" = "xno" ; then
 fi
 if test "x$ac_cv_func_timingsafe_memcmp" = "xno" ; then
 	echo timingsafe_memcmp >> $crypto_p_sym
+fi
+if test "x$HOSTARCH" = "xintel" ; then
+	echo OPENSSL_ia32cap_P >> $crypto_p_sym
 fi
 if test "x$HOST_OS" = "xwin" ; then
 	echo posix_perror >> $crypto_p_sym

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -153,6 +153,7 @@ AC_DEFUN([GENERATE_CRYPTO_PORTABLE_SYM], [
 AS_CASE([$host_cpu],
 	[i?86], [HOSTARCH=intel],
 	[x86_64], [HOSTARCH=intel],
+	[amd64], [HOSTARCH=intel],
 )
 AC_SUBST([HOSTARCH])
 crypto_sym=$srcdir/crypto/crypto.sym


### PR DESCRIPTION
This fixes #305 by only exporting OPENSSL_ia32cap_P where it is compiled.