### PR TITLE
Add hkdf and Add in_addr_t for Windows

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -463,6 +463,7 @@ set(
 	gost/gostr341001_pmeth.c
 	gost/gostr341194.c
 	gost/streebog.c
+	hkdf/hkdf.c
 	hmac/hm_ameth.c
 	hmac/hm_pmeth.c
 	hmac/hmac.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -583,6 +583,9 @@ noinst_HEADERS += gost/gost.h
 noinst_HEADERS += gost/gost_asn1.h
 noinst_HEADERS += gost/gost_locl.h
 
+# hkdf
+libcrypto_la_SOURCES += hkdf/hkdf.c
+
 # hmac
 libcrypto_la_SOURCES += hmac/hm_ameth.c
 libcrypto_la_SOURCES += hmac/hm_pmeth.c

--- a/include/compat/sys/types.h
+++ b/include/compat/sys/types.h
@@ -20,12 +20,14 @@
 
 #ifdef __MINGW32__
 #include <_bsd_types.h>
+typedef uint32_t        in_addr_t;
 #endif
 
 #ifdef _MSC_VER
 typedef unsigned char   u_char;
 typedef unsigned short  u_short;
 typedef unsigned int    u_int;
+typedef uint32_t        in_addr_t;
 
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,6 +178,11 @@ add_executable(gost2814789t gost2814789t.c)
 target_link_libraries(gost2814789t ${TESTS_LIBS})
 add_test(gost2814789t gost2814789t)
 
+# hkdf_test
+add_executable(hkdf_test hkdf_test.c)
+target_link_libraries(hkdf_test ${TESTS_LIBS})
+add_test(hkdf_test hkdf_test)
+
 # hmactest
 add_executable(hmactest hmactest.c)
 target_link_libraries(hmactest ${TESTS_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -184,6 +184,11 @@ TESTS += gost2814789t
 check_PROGRAMS += gost2814789t
 gost2814789t_SOURCES = gost2814789t.c
 
+# hkdf_test
+TESTS += hkdf_test
+check_PROGRAMS += hkdf_test
+hmactest_SOURCES = hkdf_est.c
+
 # hmactest
 TESTS += hmactest
 check_PROGRAMS += hmactest

--- a/update.sh
+++ b/update.sh
@@ -121,7 +121,7 @@ copy_hdrs $libcrypto_src "stack/stack.h lhash/lhash.h stack/safestack.h
 	ossl_typ.h err/err.h crypto.h comp/comp.h x509/x509.h buffer/buffer.h
 	objects/objects.h asn1/asn1.h bn/bn.h ec/ec.h ecdsa/ecdsa.h
 	ecdh/ecdh.h rsa/rsa.h sha/sha.h x509/x509_vfy.h pkcs7/pkcs7.h pem/pem.h
-	pem/pem2.h hmac/hmac.h rand/rand.h md5/md5.h
+	pem/pem2.h hkdf/hkdf.h hmac/hmac.h rand/rand.h md5/md5.h
 	asn1/asn1_mac.h x509v3/x509v3.h conf/conf.h ocsp/ocsp.h
 	aes/aes.h modes/modes.h asn1/asn1t.h dso/dso.h bf/blowfish.h
 	bio/bio.h cast/cast.h cmac/cmac.h conf/conf_api.h des/des.h dh/dh.h


### PR DESCRIPTION
- Add 1st step of hkdf function
- Add in_addr_t in include/compat/sys/types.h for Windows build