### PR TITLE
Fix CMake module include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CheckLibraryExists)
 include(CheckIncludeFiles)
 include(CheckTypeSize)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 include(cmake_export_symbol)
 
 project (LibreSSL C)


### PR DESCRIPTION
Need to search the current directory, not the overall project root directory
if this is being included as a sub-dependency of another project.