### PR TITLE
add prototype definitions of asprintf and vasprintf for CYGWIN build

### DIFF
--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -13,6 +13,7 @@ case $host_os in
 		;;
 	*cygwin*)
 		HOST_OS=cygwin
+		CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
 		;;
 	*darwin*)
 		HOST_OS=darwin


### PR DESCRIPTION
- define _GNU_SOURCE in case of cygwin

As compilation warning report by @Dravion