### PR TITLE
Add patch for gcm128.c to build with Visual Studio

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -559,7 +559,6 @@ set(
 	rsa/rsa_pss.c
 	rsa/rsa_saos.c
 	rsa/rsa_sign.c
-	rsa/rsa_ssl.c
 	rsa/rsa_x931.c
 	sha/sha1_one.c
 	sha/sha1dgst.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -799,7 +799,6 @@ libcrypto_la_SOURCES += rsa/rsa_prn.c
 libcrypto_la_SOURCES += rsa/rsa_pss.c
 libcrypto_la_SOURCES += rsa/rsa_saos.c
 libcrypto_la_SOURCES += rsa/rsa_sign.c
-libcrypto_la_SOURCES += rsa/rsa_ssl.c
 libcrypto_la_SOURCES += rsa/rsa_x931.c
 noinst_HEADERS += rsa/rsa_locl.h
 

--- a/patches/gcm128.c.patch
+++ b/patches/gcm128.c.patch
@@ -1,0 +1,56 @@
+--- crypto/modes/gcm128.c.orig	Tue Aug 29 23:04:52 2017
++++ crypto/modes/gcm128.c	Tue Aug 29 23:06:31 2017
+@@ -224,7 +224,7 @@ static void gcm_gmult_8bit(u64 Xi[2], const u128 Htabl
+ 		rem  = (size_t)Z.lo&0xff;
+ 		Z.lo = (Z.hi<<56)|(Z.lo>>8);
+ 		Z.hi = (Z.hi>>8);
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ 		Z.hi ^= rem_8bit[rem];
+ #else
+ 		Z.hi ^= (u64)rem_8bit[rem]<<32;
+@@ -347,7 +347,7 @@ static void gcm_gmult_4bit(u64 Xi[2], const u128 Htabl
+ 		rem  = (size_t)Z.lo&0xf;
+ 		Z.lo = (Z.hi<<60)|(Z.lo>>4);
+ 		Z.hi = (Z.hi>>4);
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ 		Z.hi ^= rem_4bit[rem];
+ #else
+ 		Z.hi ^= (u64)rem_4bit[rem]<<32;
+@@ -364,7 +364,7 @@ static void gcm_gmult_4bit(u64 Xi[2], const u128 Htabl
+ 		rem  = (size_t)Z.lo&0xf;
+ 		Z.lo = (Z.hi<<60)|(Z.lo>>4);
+ 		Z.hi = (Z.hi>>4);
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ 		Z.hi ^= rem_4bit[rem];
+ #else
+ 		Z.hi ^= (u64)rem_4bit[rem]<<32;
+@@ -421,7 +421,7 @@ static void gcm_ghash_4bit(u64 Xi[2],const u128 Htable
+ 		rem  = (size_t)Z.lo&0xf;
+ 		Z.lo = (Z.hi<<60)|(Z.lo>>4);
+ 		Z.hi = (Z.hi>>4);
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ 		Z.hi ^= rem_4bit[rem];
+ #else
+ 		Z.hi ^= (u64)rem_4bit[rem]<<32;
+@@ -439,7 +439,7 @@ static void gcm_ghash_4bit(u64 Xi[2],const u128 Htable
+ 		rem  = (size_t)Z.lo&0xf;
+ 		Z.lo = (Z.hi<<60)|(Z.lo>>4);
+ 		Z.hi = (Z.hi>>4);
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ 		Z.hi ^= rem_4bit[rem];
+ #else
+ 		Z.hi ^= (u64)rem_4bit[rem]<<32;
+@@ -588,7 +588,7 @@ static void gcm_gmult_1bit(u64 Xi[2],const u64 H[2])
+ 
+ 	for (j=0; j<16/sizeof(long); ++j) {
+ #if BYTE_ORDER == LITTLE_ENDIAN
+-#ifdef _LP64
++#if defined(_LP64) || defined(_WIN64)
+ #ifdef BSWAP8
+ 			X = (long)(BSWAP8(xi[j]));
+ #else

--- a/patches/gcm128.c.patch
+++ b/patches/gcm128.c.patch
@@ -5,7 +5,7 @@
  		Z.lo = (Z.hi<<56)|(Z.lo>>8);
  		Z.hi = (Z.hi>>8);
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  		Z.hi ^= rem_8bit[rem];
  #else
  		Z.hi ^= (u64)rem_8bit[rem]<<32;
@@ -14,7 +14,7 @@
  		Z.lo = (Z.hi<<60)|(Z.lo>>4);
  		Z.hi = (Z.hi>>4);
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  		Z.hi ^= rem_4bit[rem];
  #else
  		Z.hi ^= (u64)rem_4bit[rem]<<32;
@@ -23,7 +23,7 @@
  		Z.lo = (Z.hi<<60)|(Z.lo>>4);
  		Z.hi = (Z.hi>>4);
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  		Z.hi ^= rem_4bit[rem];
  #else
  		Z.hi ^= (u64)rem_4bit[rem]<<32;
@@ -32,7 +32,7 @@
  		Z.lo = (Z.hi<<60)|(Z.lo>>4);
  		Z.hi = (Z.hi>>4);
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  		Z.hi ^= rem_4bit[rem];
  #else
  		Z.hi ^= (u64)rem_4bit[rem]<<32;
@@ -41,7 +41,7 @@
  		Z.lo = (Z.hi<<60)|(Z.lo>>4);
  		Z.hi = (Z.hi>>4);
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  		Z.hi ^= rem_4bit[rem];
  #else
  		Z.hi ^= (u64)rem_4bit[rem]<<32;
@@ -50,7 +50,7 @@
  	for (j=0; j<16/sizeof(long); ++j) {
  #if BYTE_ORDER == LITTLE_ENDIAN
 -#ifdef _LP64
-+#if defined(_LP64) || defined(_WIN64)
++#if SIZE_MAX == 0xffffffffffffffff
  #ifdef BSWAP8
  			X = (long)(BSWAP8(xi[j]));
  #else


### PR DESCRIPTION
Hi,

I found regress aeadtest and gcm128test are failed on Windows Visual Studio.
And the commit https://github.com/libressl-portable/openbsd/commit/2005e957cabbfd8d5afc9bbc74ccf6144c448b0d relates to this issue.
By this commit, it detects the size of pointer with "#ifdef _LP64" instead of "sizeof(size_t)" on runtime.
Windows Visual Studio seems not to define "_LP64", and that brings wrong instruction execution.
To detect this on Windows Visual Studio, I think we can use "_WIN64".
I made a patch for this issue rather than requesting upstream modification since this issue is only for Windows.

Any comments are appreciated.