### PR TITLE
netcat.c.patch: eliminate syntax error from patch

### DIFF
--- a/patches/netcat.c.patch
+++ b/patches/netcat.c.patch
@@ -134,7 +134,7 @@
  			err(1, "set IPv6 traffic class");
 +#else
 +		else if (af == AF_INET6) {
-+			errno = ENOPROTOOPT
++			errno = ENOPROTOOPT;
 +			err(1, "set IPv6 traffic class not supported");
 +		}
 +#endif


### PR DESCRIPTION
If the target system does not define IPV6_TCLASS, this part of
the patch handles that with an ENOPROTOOPT error rather than
failing to compile.

Unfortunately it's missing a trailing semicolon leading to
a compilation error.

Add the missing semicolon to fix the problem.

Signed-off-by: Kyle J. McKay <mackyle@gmail.com>

---

Note that the original version of this patch was formatted slightly differently and it seems that during the reformatting a syntax error was introduced.

Would it be possible to pick this fix up for the next portable release?