### PR TITLE
Add tls/tls_keypair.c

### DIFF
--- a/include/compat/sys/stat.h
+++ b/include/compat/sys/stat.h
@@ -10,8 +10,17 @@
 #include_next <sys/stat.h>
 
 /* for old MinGW */
+#ifndef S_IRWXU
+#define S_IRWXU         0
+#endif
+#ifndef S_IRWXG
+#define S_IRWXG         0
+#endif
 #ifndef S_IRGRP
 #define S_IRGRP         0
+#endif
+#ifndef S_IRWXO
+#define S_IRWXO         0
 #endif
 #ifndef S_IROTH
 #define S_IROTH         0
@@ -65,12 +74,15 @@
 #endif
 
 #if defined(_MSC_VER)
+#   define S_IRWXU  0                           /* RWX user */
 #   define S_IRUSR  S_IREAD                     /* Read user */
 #   define S_IWUSR  S_IWRITE                    /* Write user */
 #   define S_IXUSR  0                           /* Execute user */
+#   define S_IRWXG  0                           /* RWX group */
 #   define S_IRGRP  0                           /* Read group */
 #   define S_IWGRP  0                           /* Write group */
 #   define S_IXGRP  0                           /* Execute group */
+#   define S_IRWXO  0                           /* RWX others */
 #   define S_IROTH  0                           /* Read others */
 #   define S_IWOTH  0                           /* Write others */
 #   define S_IXOTH  0                           /* Execute others */

--- a/include/compat/sys/types.h
+++ b/include/compat/sys/types.h
@@ -28,6 +28,7 @@ typedef unsigned char   u_char;
 typedef unsigned short  u_short;
 typedef unsigned int    u_int;
 typedef uint32_t        in_addr_t;
+typedef uint32_t        mode_t;
 
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -11,6 +11,7 @@ set(
 	tls_client.c
 	tls_config.c
 	tls_conninfo.c
+	tls_keypair.c
 	tls_server.c
 	tls_ocsp.c
 	tls_peer.c

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -23,6 +23,7 @@ libtls_la_SOURCES += tls_client.c
 libtls_la_SOURCES += tls_bio_cb.c
 libtls_la_SOURCES += tls_config.c
 libtls_la_SOURCES += tls_conninfo.c
+libtls_la_SOURCES += tls_keypair.c
 libtls_la_SOURCES += tls_server.c
 libtls_la_SOURCES += tls_ocsp.c
 libtls_la_SOURCES += tls_peer.c


### PR DESCRIPTION
- This PR solves linux and OSX build fail
- Added file permission define required by Windows and MinGW
- For Windows and MinGW build, need pread(), pwrite(), ftruncate() and gituid().