### PR TITLE
Add compat bits for libtls on Windows

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -217,6 +217,7 @@ set(
 	bio/bio_cb.c
 	bio/bio_err.c
 	bio/bio_lib.c
+	bio/bio_meth.c
 	bio/bss_acpt.c
 	bio/bss_bio.c
 	bio/bss_conn.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -345,6 +345,7 @@ libcrypto_la_SOURCES += bio/bf_null.c
 libcrypto_la_SOURCES += bio/bio_cb.c
 libcrypto_la_SOURCES += bio/bio_err.c
 libcrypto_la_SOURCES += bio/bio_lib.c
+libcrypto_la_SOURCES += bio/bio_meth.c
 libcrypto_la_SOURCES += bio/bss_acpt.c
 libcrypto_la_SOURCES += bio/bss_bio.c
 libcrypto_la_SOURCES += bio/bss_conn.c

--- a/include/compat/sys/types.h
+++ b/include/compat/sys/types.h
@@ -21,6 +21,7 @@
 #ifdef __MINGW32__
 #include <_bsd_types.h>
 typedef uint32_t        in_addr_t;
+typedef uint32_t        uid_t;
 #endif
 
 #ifdef _MSC_VER
@@ -29,6 +30,7 @@ typedef unsigned short  u_short;
 typedef unsigned int    u_int;
 typedef uint32_t        in_addr_t;
 typedef uint32_t        mode_t;
+typedef uint32_t        uid_t;
 
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -7,7 +7,16 @@
 #define LIBCRYPTOCOMPAT_UNISTD_H
 
 #ifndef _MSC_VER
+
 #include_next <unistd.h>
+
+#ifdef __MINGW32__
+int ftruncate(int fd, off_t length);
+uid_t getuid(void);
+ssize_t pread(int d, void *buf, size_t nbytes, off_t offset);
+ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
+#endif
+
 #else
 
 #include <stdlib.h>
@@ -22,9 +31,18 @@
 #define X_OK    0
 #define F_OK    0
 
+#define SEEK_SET        0
+#define SEEK_CUR        1
+#define SEEK_END        2
+
 #define access _access
 
 unsigned int sleep(unsigned int seconds);
+
+int ftruncate(int fd, off_t length);
+uid_t getuid(void);
+ssize_t pread(int d, void *buf, size_t nbytes, off_t offset);
+ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
 
 #endif
 

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -19,6 +19,16 @@ set(
 	tls_verify.c
 )
 
+if(CMAKE_HOST_WIN32)
+set(
+	TLS_SRC
+	${TLS_SRC}
+	compat/ftruncate.c
+	compat/getuid.c
+	compat/pread.c
+	compat/pwrite.c
+)
+endif()
 
 if(NOT "${OPENSSLDIR}" STREQUAL "")
 	add_definitions(-D_PATH_SSL_CA_FILE=\"${OPENSSLDIR}/cert.pem\")

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -30,3 +30,10 @@ libtls_la_SOURCES += tls_peer.c
 libtls_la_SOURCES += tls_util.c
 libtls_la_SOURCES += tls_verify.c
 noinst_HEADERS = tls_internal.h
+
+if HOST_WIN
+libtls_la_SOURCES += compat/ftruncate.c
+libtls_la_SOURCES += compat/getuid.c
+libtls_la_SOURCES += compat/pread.c
+libtls_la_SOURCES += compat/pwrite.c
+endif

--- a/tls/compat/ftruncate.c
+++ b/tls/compat/ftruncate.c
@@ -1,0 +1,13 @@
+/*
+ * Public domain
+ *
+ * Kinichiro Inoguchi <inoguchi@openbsd.org>
+ */
+
+#include <unistd.h>
+
+int
+ftruncate(int fd, off_t length)
+{
+	return _chsize(fd, length);
+}

--- a/tls/compat/getuid.c
+++ b/tls/compat/getuid.c
@@ -1,0 +1,14 @@
+/*
+ * Public domain
+ *
+ * Kinichiro Inoguchi <inoguchi@openbsd.org>
+ */
+
+#include <unistd.h>
+
+uid_t
+getuid(void)
+{
+	/* Windows fstat sets 0 as st_uid */
+	return 0;
+}

--- a/tls/compat/pread.c
+++ b/tls/compat/pread.c
@@ -1,0 +1,23 @@
+/*
+ * Public domain
+ *
+ * Kinichiro Inoguchi <inoguchi@openbsd.org>
+ */
+
+#include <unistd.h>
+
+ssize_t
+pread(int d, void *buf, size_t nbytes, off_t offset)
+{
+	off_t cpos, opos, rpos;
+	ssize_t bytes;
+	if((cpos = lseek(d, 0, SEEK_CUR)) == -1)
+		return -1;
+	if((opos = lseek(d, offset, SEEK_SET)) == -1)
+		return -1;
+	if((bytes = read(d, buf, nbytes)) == -1)
+		return -1;
+	if((rpos = lseek(d, cpos, SEEK_SET)) == -1)
+		return -1;
+	return bytes;
+}

--- a/tls/compat/pwrite.c
+++ b/tls/compat/pwrite.c
@@ -1,0 +1,23 @@
+/*
+ * Public domain
+ *
+ * Kinichiro Inoguchi <inoguchi@openbsd.org>
+ */
+
+#include <unistd.h>
+
+ssize_t
+pwrite(int d, const void *buf, size_t nbytes, off_t offset)
+{
+	off_t cpos, opos, rpos;
+	ssize_t bytes;
+	if((cpos = lseek(d, 0, SEEK_CUR)) == -1)
+		return -1;
+	if((opos = lseek(d, offset, SEEK_SET)) == -1)
+		return -1;
+	if((bytes = write(d, buf, nbytes)) == -1)
+		return -1;
+	if((rpos = lseek(d, cpos, SEEK_SET)) == -1)
+		return -1;
+	return bytes;
+}


### PR DESCRIPTION
This is temporary solution to prevent build break of libtls on Windows platform.
It is just replacing posix functions with Windows suitable one.
We might have more high level solutions for this, but now I would like to solve build first.
I verified pread() and pwrite() with this test code.
https://gist.github.com/kinichiro/63d6262c5cdb3e0fe0bd5d0233a5ea03
I would appreciate any comments and suggestions.