### PR TITLE
Fix using right functions for file descriptor with MS Visual Studio

### DIFF
--- a/patches/keypairtest.c.patch
+++ b/patches/keypairtest.c.patch
@@ -1,0 +1,13 @@
+--- tests/keypairtest.c.orig	Sun Mar 18 00:31:20 2018
++++ tests/keypairtest.c	Sun Mar 18 00:31:33 2018
+@@ -15,6 +15,10 @@
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#ifdef _MSC_VER
++#define NO_REDEF_POSIX_FUNCTIONS
++#endif
++
+ #include <sys/stat.h>
+ 
+ #include <err.h>

--- a/patches/tls_config.c.patch
+++ b/patches/tls_config.c.patch
@@ -1,0 +1,13 @@
+--- tls/tls_config.c.orig	Sun Mar 18 00:29:59 2018
++++ tls/tls_config.c	Sun Mar 18 00:30:51 2018
+@@ -15,6 +15,10 @@
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#ifdef _MSC_VER
++#define NO_REDEF_POSIX_FUNCTIONS
++#endif
++
+ #include <sys/stat.h>
+ 
+ #include <ctype.h>

--- a/patches/tls_util.c.patch
+++ b/patches/tls_util.c.patch
@@ -1,0 +1,13 @@
+--- tls/tls_util.c.orig	Sun Mar 18 00:30:07 2018
++++ tls/tls_util.c	Sun Mar 18 00:31:09 2018
+@@ -17,6 +17,10 @@
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#ifdef _MSC_VER
++#define NO_REDEF_POSIX_FUNCTIONS
++#endif
++
+ #include <sys/stat.h>
+ 
+ #include <stdlib.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,14 +215,12 @@ target_link_libraries(igetest ${TESTS_LIBS})
 add_test(igetest igetest)
 
 # keypairtest
-if(NOT MSVC)
 add_executable(keypairtest keypairtest.c)
 target_link_libraries(keypairtest ${TESTS_LIBS})
 add_test(keypairtest keypairtest
 	${CMAKE_CURRENT_SOURCE_DIR}/ca.pem
 	${CMAKE_CURRENT_SOURCE_DIR}/server.pem
 	${CMAKE_CURRENT_SOURCE_DIR}/server.pem)
-endif()
 
 # md4test
 add_executable(md4test md4test.c)

--- a/tls/compat/ftruncate.c
+++ b/tls/compat/ftruncate.c
@@ -4,6 +4,8 @@
  * Kinichiro Inoguchi <inoguchi@openbsd.org>
  */
 
+#ifdef _WIN32
+
 #include <unistd.h>
 
 int
@@ -11,3 +13,5 @@ ftruncate(int fd, off_t length)
 {
 	return _chsize(fd, length);
 }
+
+#endif

--- a/tls/compat/getuid.c
+++ b/tls/compat/getuid.c
@@ -4,6 +4,8 @@
  * Kinichiro Inoguchi <inoguchi@openbsd.org>
  */
 
+#ifdef _WIN32
+
 #include <unistd.h>
 
 uid_t
@@ -12,3 +14,5 @@ getuid(void)
 	/* Windows fstat sets 0 as st_uid */
 	return 0;
 }
+
+#endif

--- a/tls/compat/pread.c
+++ b/tls/compat/pread.c
@@ -4,6 +4,10 @@
  * Kinichiro Inoguchi <inoguchi@openbsd.org>
  */
 
+#ifdef _WIN32
+
+#define NO_REDEF_POSIX_FUNCTIONS
+
 #include <unistd.h>
 
 ssize_t
@@ -21,3 +25,5 @@ pread(int d, void *buf, size_t nbytes, off_t offset)
 		return -1;
 	return bytes;
 }
+
+#endif

--- a/tls/compat/pwrite.c
+++ b/tls/compat/pwrite.c
@@ -4,6 +4,10 @@
  * Kinichiro Inoguchi <inoguchi@openbsd.org>
  */
 
+#ifdef _WIN32
+
+#define NO_REDEF_POSIX_FUNCTIONS
+
 #include <unistd.h>
 
 ssize_t
@@ -21,3 +25,5 @@ pwrite(int d, const void *buf, size_t nbytes, off_t offset)
 		return -1;
 	return bytes;
 }
+
+#endif


### PR DESCRIPTION
After investigating keypairtest issue with Visual Studio, I found that it used `posix_open` and `posix_read` for file descriptor instead of using `open` and `read` .
This PR fix that and bring back keypairtest with Visual Studio, again.