### PR TITLE
Windows updates - add pthread_self/equal and pull in new init symbols

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -112,6 +112,7 @@ set(
 	${CRYPTO_SRC}
 	cpt_err.c
 	cryptlib.c
+	crypto_init.c
 	cversion.c
 	ex_data.c
 	malloc-wrapper.c
@@ -324,6 +325,7 @@ set(
 	dsa/dsa_gen.c
 	dsa/dsa_key.c
 	dsa/dsa_lib.c
+	dsa/dsa_meth.c
 	dsa/dsa_ossl.c
 	dsa/dsa_pmeth.c
 	dsa/dsa_prn.c
@@ -552,6 +554,7 @@ set(
 	rsa/rsa_err.c
 	rsa/rsa_gen.c
 	rsa/rsa_lib.c
+	rsa/rsa_meth.c
 	rsa/rsa_none.c
 	rsa/rsa_oaep.c
 	rsa/rsa_pk1.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -209,6 +209,7 @@ endif
 
 libcrypto_la_SOURCES += cpt_err.c
 libcrypto_la_SOURCES += cryptlib.c
+libcrypto_la_SOURCES += crypto_init.c
 libcrypto_la_SOURCES += cversion.c
 libcrypto_la_SOURCES += ex_data.c
 libcrypto_la_SOURCES += malloc-wrapper.c
@@ -485,6 +486,7 @@ libcrypto_la_SOURCES += dsa/dsa_err.c
 libcrypto_la_SOURCES += dsa/dsa_gen.c
 libcrypto_la_SOURCES += dsa/dsa_key.c
 libcrypto_la_SOURCES += dsa/dsa_lib.c
+libcrypto_la_SOURCES += dsa/dsa_meth.c
 libcrypto_la_SOURCES += dsa/dsa_ossl.c
 libcrypto_la_SOURCES += dsa/dsa_pmeth.c
 libcrypto_la_SOURCES += dsa/dsa_prn.c
@@ -785,6 +787,7 @@ libcrypto_la_SOURCES += rsa/rsa_eay.c
 libcrypto_la_SOURCES += rsa/rsa_err.c
 libcrypto_la_SOURCES += rsa/rsa_gen.c
 libcrypto_la_SOURCES += rsa/rsa_lib.c
+libcrypto_la_SOURCES += rsa/rsa_meth.c
 libcrypto_la_SOURCES += rsa/rsa_none.c
 libcrypto_la_SOURCES += rsa/rsa_oaep.c
 libcrypto_la_SOURCES += rsa/rsa_pk1.c

--- a/include/compat/pthread.h
+++ b/include/compat/pthread.h
@@ -18,23 +18,43 @@
 struct pthread_once {
 	INIT_ONCE once;
 };
-
 typedef struct pthread_once pthread_once_t;
 
-static BOOL CALLBACK _pthread_once_win32_cb(PINIT_ONCE once, PVOID param, PVOID *context)
+static inline BOOL CALLBACK
+_pthread_once_win32_cb(PINIT_ONCE once, PVOID param, PVOID *context)
 {
 	void (*cb) (void) = param;
 	cb();
 	return TRUE;
 }
 
-static int pthread_once(pthread_once_t *once, void (*cb) (void))
+static inline int
+pthread_once(pthread_once_t *once, void (*cb) (void))
 {
 	BOOL rc = InitOnceExecuteOnce(&once->once, _pthread_once_win32_cb, cb, NULL);
 	if (rc == 0)
 		return -1;
 	else
 		return 0;
+}
+
+struct pthread {
+	HANDLE handle;
+};
+typedef struct pthread pthread_t;
+
+static inline pthread_t
+pthread_self(void)
+{
+	pthread_t self;
+	self.handle = GetCurrentThread();
+	return self;
+}
+
+static inline int
+pthread_equal(pthread_t t1, pthread_t t2)
+{
+	return t1.handle == t2.handle;
 }
 
 #else

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
 	ssl_ciph.c
 	ssl_clnt.c
 	ssl_err.c
+	ssl_init.c
 	ssl_lib.c
 	ssl_packet.c
 	ssl_pkt.c

--- a/ssl/Makefile.am
+++ b/ssl/Makefile.am
@@ -31,6 +31,7 @@ libssl_la_SOURCES += ssl_cert.c
 libssl_la_SOURCES += ssl_ciph.c
 libssl_la_SOURCES += ssl_clnt.c
 libssl_la_SOURCES += ssl_err.c
+libssl_la_SOURCES += ssl_init.c
 libssl_la_SOURCES += ssl_lib.c
 libssl_la_SOURCES += ssl_packet.c
 libssl_la_SOURCES += ssl_pkt.c


### PR DESCRIPTION
This adds Windows support on current builds and adds new _init files.