### PR TITLE
Add appveyor support for Window CI/CD

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
-  VSTEST: OFF
+  VSTEST: ON
   
   matrix:
     # x86 builds
@@ -48,4 +48,4 @@ build_script:
   - cmake --build . --config %CONFIG%
 
 test_script:
-  - ctest
+  - ctest -C %CONFIG%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
       SHARED_LIBS: ON
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Debug
-      SHARED_LIBS: ON
+      SHARED_LIBS: OFF
 
     # x64 builds
     - GENERATOR: Visual Studio 14 2015 Win64
@@ -29,7 +29,7 @@ environment:
       SHARED_LIBS: ON
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Debug
-      SHARED_LIBS: ON
+      SHARED_LIBS: OFF
 
 init:
   # update mysy2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+environment:
+  PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
+  VSTEST: OFF
+  
+  matrix:
+    # x86 builds
+    - GENERATOR: Visual Studio 14 2015
+      CONFIG: Release
+      SHARED_LIBS: ON
+    - GENERATOR: Visual Studio 14 2015
+      CONFIG: Release
+      SHARED_LIBS: OFF
+    - GENERATOR: Visual Studio 14 2015
+      CONFIG: Debug
+      SHARED_LIBS: ON
+    - GENERATOR: Visual Studio 14 2015
+      CONFIG: Debug
+      SHARED_LIBS: ON
+
+    # x64 builds
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CONFIG: Release
+      SHARED_LIBS: ON
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CONFIG: Release
+      SHARED_LIBS: OFF
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CONFIG: Debug
+      SHARED_LIBS: ON
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CONFIG: Debug
+      SHARED_LIBS: ON
+
+init:
+  # update mysy2
+  - C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S autoconf perl"
+  - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S git"
+  
+before_build:
+  - bash autogen.sh
+  - mkdir build
+  - cd build
+  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED=%SHARED_LIBS% -DENABLE_VSTEST=%VSTEST%
+
+build_script:
+  - cmake --build . --config %CONFIG%
+
+test_script:
+  - ctest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,42 @@
 environment:
   PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
-  VSTEST: ON
   
   matrix:
     # x86 builds
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Release
       SHARED_LIBS: ON
+      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Release
       SHARED_LIBS: OFF
+      VSTEST: ON      
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Debug
       SHARED_LIBS: ON
+      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Debug
       SHARED_LIBS: OFF
+      VSTEST: ON
 
     # x64 builds
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Release
       SHARED_LIBS: ON
+      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Release
       SHARED_LIBS: OFF
+      VSTEST: ON
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Debug
       SHARED_LIBS: ON
+      VSTEST: OFF      
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Debug
       SHARED_LIBS: OFF
+      VSTEST: ON
 
 init:
   # update mysy2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ before_build:
   - bash autogen.sh
   - mkdir build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED=%SHARED_LIBS% -DENABLE_VSTEST=%VSTEST%
+  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%SHARED_LIBS% -DENABLE_VSTEST=%VSTEST%
 
 build_script:
   - cmake --build . --config %CONFIG%


### PR DESCRIPTION
LibreSSL does not have a Visual Studio build so its not clear if the CMake build works for it. This adds [AppVeyor](https://www.appveyor.com/) which is free for open source and has a Windows stack available for it.