### PR TITLE
Use BUILD_SHARED_LIBS to specify library type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,23 +262,7 @@ if(ENABLE_ASM)
 	endif()
 endif()
 
-if(NOT (CMAKE_SYSTEM_NAME MATCHES "(Darwin|CYGWIN)"))
-	set(BUILD_SHARED true)
-endif()
-
-# USE_SHARED builds applications (e.g. openssl) using shared LibreSSL.
-# By default, applications use LibreSSL static library to avoid dependencies.
-# USE_SHARED isn't set by default; use -DUSE_SHARED=ON with CMake to enable.
-# Can be helpful for debugging; don't use for public releases.
-if(NOT BUILD_SHARED)
-	set(USE_SHARED off)
-endif()
-
-if(USE_SHARED)
-	set(OPENSSL_LIBS tls-shared ssl-shared crypto-shared)
-else()
-	set(OPENSSL_LIBS tls ssl crypto)
-endif()
+set(OPENSSL_LIBS tls ssl crypto)
 
 if(WIN32)
 	set(OPENSSL_LIBS ${OPENSSL_LIBS} ws2_32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ string(REGEX REPLACE "\\..*" "" TLS_MAJOR_VERSION ${TLS_VERSION})
 
 option(LIBRESSL_SKIP_INSTALL "Skip installation" ${LIBRESSL_SKIP_INSTALL})
 option(LIBRESSL_APPS "Build apps" ON)
+option(LIBRESSL_TESTS "Build tests" ON)
 option(ENABLE_ASM "Enable assembly" ON)
 option(ENABLE_EXTRATESTS "Enable extra tests that may be unreliable on some platforms" OFF)
 option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
-option(ENABLE_VSTEST "Enable test on Visual Studio" OFF)
 set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
 
 if(NOT LIBRESSL_SKIP_INSTALL)
@@ -300,7 +300,8 @@ add_subdirectory(include)
 if(NOT MSVC)
 	add_subdirectory(man)
 endif()
-if(NOT MSVC OR ENABLE_VSTEST)
+# Tests require the openssl executable and are unavailable when building shared libraries
+if(LIBRESSL_APPS AND LIBRESSL_TESTS AND NOT BUILD_SHARED_LIBS)
 	add_subdirectory(tests)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ into other projects or build by itself.
 | Option Name | Default | Description
 | ------------ | -----: | ------
 |  LIBRESSL_SKIP_INSTALL | OFF | allows skipping install() rules.  Can be specified from command line using <br>```-DLIBRESSL_SKIP_INSTALL=ON``` |
+|  LIBRESSL_APPS | ON | allows skipping application builds. Apps are required to run tests |
+|  LIBRESSL_TESTS | ON | allows skipping of tests. Tests are only available in static builds |
+|  BUILD_SHARED_LIBS | OFF | CMake option for building shared libraries. |
 |  ENABLE_ASM | ON | builds assembly optimized rules. |
 |  ENABLE_EXTRATESTS | OFF | Enable extra tests that may be unreliable on some platforms |
 |  ENABLE_NC | OFF | Enable installing TLS-enabled nc(1) |
-|  ENABLE_VSTEST | OFF | Enable test on Visual Studio |
 |  OPENSSLDIR | Blank | Set the default openssl directory.  Can be specified from command line using <br>```-DOPENSSLDIR=<dirname>``` |
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,37 +6,29 @@ environment:
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Release
       SHARED_LIBS: ON
-      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Release
       SHARED_LIBS: OFF
-      VSTEST: ON      
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Debug
       SHARED_LIBS: ON
-      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015
       CONFIG: Debug
       SHARED_LIBS: OFF
-      VSTEST: ON
 
     # x64 builds
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Release
       SHARED_LIBS: ON
-      VSTEST: OFF
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Release
       SHARED_LIBS: OFF
-      VSTEST: ON
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Debug
       SHARED_LIBS: ON
-      VSTEST: OFF      
     - GENERATOR: Visual Studio 14 2015 Win64
       CONFIG: Debug
       SHARED_LIBS: OFF
-      VSTEST: ON
 
 init:
   # update mysy2
@@ -49,7 +41,7 @@ before_build:
   - bash autogen.sh
   - mkdir build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%SHARED_LIBS% -DENABLE_VSTEST=%VSTEST%
+  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%SHARED_LIBS%
 
 build_script:
   - cmake --build . --config %CONFIG%

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -809,29 +809,23 @@ if(EXTRA_EXPORT)
 	endforeach()
 endif()
 
-add_library(crypto-objects OBJECT ${CRYPTO_SRC})
-set(CRYPTO_LIBRARIES crypto)
-if (BUILD_SHARED)
-	list(APPEND CRYPTO_LIBRARIES crypto-shared)
-	add_library(crypto STATIC $<TARGET_OBJECTS:crypto-objects>)
-	add_library(crypto-shared SHARED $<TARGET_OBJECTS:crypto-objects>)
-	export_symbol(crypto-shared ${CMAKE_CURRENT_BINARY_DIR}/crypto_p.sym)
+add_library(crypto ${CRYPTO_SRC})
+if (BUILD_SHARED_LIBS)
+	export_symbol(crypto ${CMAKE_CURRENT_BINARY_DIR}/crypto_p.sym)
 	if (WIN32)
-		target_link_libraries(crypto-shared Ws2_32.lib)
+		target_link_libraries(crypto Ws2_32.lib)
 		set(CRYPTO_POSTFIX -${CRYPTO_MAJOR_VERSION})
 	endif()
-	set_target_properties(crypto-shared PROPERTIES
+	set_target_properties(crypto PROPERTIES
 		OUTPUT_NAME crypto${CRYPTO_POSTFIX}
 		ARCHIVE_OUTPUT_NAME crypto${CRYPTO_POSTFIX})
-	set_target_properties(crypto-shared PROPERTIES VERSION
+	set_target_properties(crypto PROPERTIES VERSION
 		${CRYPTO_VERSION} SOVERSION ${CRYPTO_MAJOR_VERSION})
-else()
-	add_library(crypto STATIC ${CRYPTO_SRC})
 endif()
 
 if(ENABLE_LIBRESSL_INSTALL)
 	install(
-		TARGETS ${CRYPTO_LIBRARIES}
+		TARGETS crypto
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/scripts/travis
+++ b/scripts/travis
@@ -12,18 +12,30 @@ if [ "x$ARCH" = "xnative" ]; then
 	make dist
 	tar zxvf libressl-*.tar.gz
 	cd libressl-*
-	mkdir build
-	cd build
+	mkdir build-static
+	mkdir build-shared
+
+	cd build-static
 
 	# test cmake and ninja
 	if [ `uname` = "Darwin" ]; then
 		cmake ..
 		make
 		make test
+
+		cd ../build-shared
+		cmake -DBUILD_SHARED_LIBS=ON ..
+		make
+		make test
 	else
 		sudo apt-get update
 		sudo apt-get install -y cmake ninja-build
 		cmake -GNinja ..
+		ninja
+		ninja test
+
+		cd ../build-shared
+		cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
 		ninja
 		ninja test
 	fi

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -47,30 +47,24 @@ set(
 	t1_srvr.c
 )
 
-add_library(ssl-objects OBJECT ${SSL_SRC})
-set(SSL_LIBRARIES ssl)
-if (BUILD_SHARED)
-	list(APPEND SSL_LIBRARIES ssl-shared)
-	add_library(ssl STATIC $<TARGET_OBJECTS:ssl-objects>)
-	add_library(ssl-shared SHARED $<TARGET_OBJECTS:ssl-objects>)
-	export_symbol(ssl-shared ${CMAKE_CURRENT_SOURCE_DIR}/ssl.sym)
-	target_link_libraries(ssl-shared crypto-shared)
+add_library(ssl ${SSL_SRC})
+if (BUILD_SHARED_LIBS)
+	export_symbol(ssl ${CMAKE_CURRENT_SOURCE_DIR}/ssl.sym)
+	target_link_libraries(ssl crypto)
 	if (WIN32)
-		target_link_libraries(ssl-shared Ws2_32.lib)
+		target_link_libraries(ssl Ws2_32.lib)
 		set(SSL_POSTFIX -${SSL_MAJOR_VERSION})
 	endif()
-	set_target_properties(ssl-shared PROPERTIES
+	set_target_properties(ssl PROPERTIES
 		OUTPUT_NAME ssl${SSL_POSTFIX}
 		ARCHIVE_OUTPUT_NAME ssl${SSL_POSTFIX})
-	set_target_properties(ssl-shared PROPERTIES VERSION ${SSL_VERSION}
+	set_target_properties(ssl PROPERTIES VERSION ${SSL_VERSION}
 		SOVERSION ${SSL_MAJOR_VERSION})
-else()
-	add_library(ssl STATIC ${SSL_SRC})
 endif()
 
 if(ENABLE_LIBRESSL_INSTALL)
 	install(
-		TARGETS ${SSL_LIBRARIES}
+		TARGETS ssl
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -427,14 +427,3 @@ add_test(verifytest verifytest)
 add_executable(x25519test x25519test.c)
 target_link_libraries(x25519test ${OPENSSL_LIBS})
 add_test(x25519test x25519test)
-
-if(ENABLE_VSTEST AND BUILD_SHARED_LIBS)
-	add_custom_command(TARGET x25519test POST_BUILD
-		COMMAND "${CMAKE_COMMAND}" -E copy
-		"$<TARGET_FILE:tls>"
-		"$<TARGET_FILE:ssl>"
-		"$<TARGET_FILE:crypto>"
-		"${CMAKE_CURRENT_BINARY_DIR}"
-		COMMENT "Copying DLLs for regression tests")
-endif()
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,155 +12,143 @@ include_directories(
 
 add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/cert.pem\")
 
-foreach(lib IN LISTS OPENSSL_LIBS)
-	if(${lib} STREQUAL "tls-shared")
-		set(TESTS_LIBS ${TESTS_LIBS} tls)
-	elseif(${lib} STREQUAL "ssl-shared")
-		set(TESTS_LIBS ${TESTS_LIBS} ssl)
-	elseif(${lib} STREQUAL "crypto-shared")
-		set(TESTS_LIBS ${TESTS_LIBS} crypto)
-	else()
-		set(TESTS_LIBS ${TESTS_LIBS} ${lib})
-	endif()
-endforeach()
-
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCE_DIR)
 
 # aeadtest
 add_executable(aeadtest aeadtest.c)
-target_link_libraries(aeadtest ${TESTS_LIBS})
+target_link_libraries(aeadtest ${OPENSSL_LIBS})
 add_test(aeadtest aeadtest ${CMAKE_CURRENT_SOURCE_DIR}/aeadtests.txt)
 
 # aes_wrap
 add_executable(aes_wrap aes_wrap.c)
-target_link_libraries(aes_wrap ${TESTS_LIBS})
+target_link_libraries(aes_wrap ${OPENSSL_LIBS})
 add_test(aes_wrap aes_wrap)
 
 # arc4randomforktest
 # Windows/mingw does not have fork, but Cygwin does.
 if(NOT CMAKE_HOST_WIN32 AND NOT CMAKE_SYSTEM_NAME MATCHES "MINGW")
 	add_executable(arc4randomforktest arc4randomforktest.c)
-	target_link_libraries(arc4randomforktest ${TESTS_LIBS})
+	target_link_libraries(arc4randomforktest ${OPENSSL_LIBS})
 	add_test(arc4randomforktest ${CMAKE_CURRENT_SOURCE_DIR}/arc4randomforktest.sh)
 endif()
 
 # asn1evp
 add_executable(asn1evp asn1evp.c)
-target_link_libraries(asn1evp ${TESTS_LIBS})
+target_link_libraries(asn1evp ${OPENSSL_LIBS})
 add_test(asn1evp asn1evp)
 
 # asn1test
 add_executable(asn1test asn1test.c)
-target_link_libraries(asn1test ${TESTS_LIBS})
+target_link_libraries(asn1test ${OPENSSL_LIBS})
 add_test(asn1test asn1test)
 
 # asn1time
 add_executable(asn1time asn1time.c)
-target_link_libraries(asn1time ${TESTS_LIBS})
+target_link_libraries(asn1time ${OPENSSL_LIBS})
 add_test(asn1time asn1time)
 
 # base64test
 add_executable(base64test base64test.c)
-target_link_libraries(base64test ${TESTS_LIBS})
+target_link_libraries(base64test ${OPENSSL_LIBS})
 add_test(base64test base64test)
 
 # bftest
 add_executable(bftest bftest.c)
-target_link_libraries(bftest ${TESTS_LIBS})
+target_link_libraries(bftest ${OPENSSL_LIBS})
 add_test(bftest bftest)
 
 # biotest
 # the BIO tests rely on resolver results that are OS and environment-specific
 if(ENABLE_EXTRATESTS)
 	add_executable(biotest biotest.c)
-	target_link_libraries(biotest ${TESTS_LIBS})
+	target_link_libraries(biotest ${OPENSSL_LIBS})
 	add_test(biotest biotest)
 endif()
 
 # bntest
 add_executable(bntest bntest.c)
 set_source_files_properties(bntest.c PROPERTIES COMPILE_FLAGS -ULIBRESSL_INTERNAL)
-target_link_libraries(bntest ${TESTS_LIBS})
+target_link_libraries(bntest ${OPENSSL_LIBS})
 add_test(bntest bntest)
 
 # bytestringtest
 add_executable(bytestringtest bytestringtest.c)
-target_link_libraries(bytestringtest ${TESTS_LIBS})
+target_link_libraries(bytestringtest ${OPENSSL_LIBS})
 add_test(bytestringtest bytestringtest)
 
 # casttest
 add_executable(casttest casttest.c)
-target_link_libraries(casttest ${TESTS_LIBS})
+target_link_libraries(casttest ${OPENSSL_LIBS})
 add_test(casttest casttest)
 
 # chachatest
 add_executable(chachatest chachatest.c)
-target_link_libraries(chachatest ${TESTS_LIBS})
+target_link_libraries(chachatest ${OPENSSL_LIBS})
 add_test(chachatest chachatest)
 
 # cipher_list
 add_executable(cipher_list cipher_list.c)
-target_link_libraries(cipher_list ${TESTS_LIBS})
+target_link_libraries(cipher_list ${OPENSSL_LIBS})
 add_test(cipher_list cipher_list)
 
 # cipherstest
 add_executable(cipherstest cipherstest.c)
-target_link_libraries(cipherstest ${TESTS_LIBS})
+target_link_libraries(cipherstest ${OPENSSL_LIBS})
 add_test(cipherstest cipherstest)
 
 # clienttest
 add_executable(clienttest clienttest.c)
-target_link_libraries(clienttest ${TESTS_LIBS})
+target_link_libraries(clienttest ${OPENSSL_LIBS})
 add_test(clienttest clienttest)
 
 # configtest
 add_executable(configtest configtest.c)
-target_link_libraries(configtest ${TESTS_LIBS})
+target_link_libraries(configtest ${OPENSSL_LIBS})
 add_test(configtest configtest)
 
 # cts128test
 add_executable(cts128test cts128test.c)
-target_link_libraries(cts128test ${TESTS_LIBS})
+target_link_libraries(cts128test ${OPENSSL_LIBS})
 add_test(cts128test cts128test)
 
 # destest
 add_executable(destest destest.c)
-target_link_libraries(destest ${TESTS_LIBS})
+target_link_libraries(destest ${OPENSSL_LIBS})
 add_test(destest destest)
 
 # dhtest
 add_executable(dhtest dhtest.c)
-target_link_libraries(dhtest ${TESTS_LIBS})
+target_link_libraries(dhtest ${OPENSSL_LIBS})
 add_test(dhtest dhtest)
 
 # dsatest
 add_executable(dsatest dsatest.c)
-target_link_libraries(dsatest ${TESTS_LIBS})
+target_link_libraries(dsatest ${OPENSSL_LIBS})
 add_test(dsatest dsatest)
 
 # ecdhtest
 add_executable(ecdhtest ecdhtest.c)
-target_link_libraries(ecdhtest ${TESTS_LIBS})
+target_link_libraries(ecdhtest ${OPENSSL_LIBS})
 add_test(ecdhtest ecdhtest)
 
 # ecdsatest
 add_executable(ecdsatest ecdsatest.c)
-target_link_libraries(ecdsatest ${TESTS_LIBS})
+target_link_libraries(ecdsatest ${OPENSSL_LIBS})
 add_test(ecdsatest ecdsatest)
 
 # ectest
 add_executable(ectest ectest.c)
-target_link_libraries(ectest ${TESTS_LIBS})
+target_link_libraries(ectest ${OPENSSL_LIBS})
 add_test(ectest ectest)
 
 # enginetest
 add_executable(enginetest enginetest.c)
-target_link_libraries(enginetest ${TESTS_LIBS})
+target_link_libraries(enginetest ${OPENSSL_LIBS})
 add_test(enginetest enginetest)
 
 # evptest
 add_executable(evptest evptest.c)
-target_link_libraries(evptest ${TESTS_LIBS})
+target_link_libraries(evptest ${OPENSSL_LIBS})
 add_test(evptest evptest ${CMAKE_CURRENT_SOURCE_DIR}/evptests.txt)
 
 # explicit_bzero
@@ -171,54 +159,54 @@ if(NOT WIN32)
 	else()
 		add_executable(explicit_bzero explicit_bzero.c compat/memmem.c)
 	endif()
-	target_link_libraries(explicit_bzero ${TESTS_LIBS})
+	target_link_libraries(explicit_bzero ${OPENSSL_LIBS})
 	add_test(explicit_bzero explicit_bzero)
 endif()
 
 # exptest
 add_executable(exptest exptest.c)
 set_source_files_properties(exptest.c PROPERTIES COMPILE_FLAGS -ULIBRESSL_INTERNAL)
-target_link_libraries(exptest ${TESTS_LIBS})
+target_link_libraries(exptest ${OPENSSL_LIBS})
 add_test(exptest exptest)
 
 # freenull
 add_executable(freenull freenull.c)
-target_link_libraries(freenull ${TESTS_LIBS})
+target_link_libraries(freenull ${OPENSSL_LIBS})
 add_test(freenull freenull)
 
 # gcm128test
 add_executable(gcm128test gcm128test.c)
-target_link_libraries(gcm128test ${TESTS_LIBS})
+target_link_libraries(gcm128test ${OPENSSL_LIBS})
 add_test(gcm128test gcm128test)
 
 # gost2814789t
 add_executable(gost2814789t gost2814789t.c)
-target_link_libraries(gost2814789t ${TESTS_LIBS})
+target_link_libraries(gost2814789t ${OPENSSL_LIBS})
 add_test(gost2814789t gost2814789t)
 
 # hkdf_test
 add_executable(hkdf_test hkdf_test.c)
-target_link_libraries(hkdf_test ${TESTS_LIBS})
+target_link_libraries(hkdf_test ${OPENSSL_LIBS})
 add_test(hkdf_test hkdf_test)
 
 # hmactest
 add_executable(hmactest hmactest.c)
-target_link_libraries(hmactest ${TESTS_LIBS})
+target_link_libraries(hmactest ${OPENSSL_LIBS})
 add_test(hmactest hmactest)
 
 # ideatest
 add_executable(ideatest ideatest.c)
-target_link_libraries(ideatest ${TESTS_LIBS})
+target_link_libraries(ideatest ${OPENSSL_LIBS})
 add_test(ideatest ideatest)
 
 # igetest
 add_executable(igetest igetest.c)
-target_link_libraries(igetest ${TESTS_LIBS})
+target_link_libraries(igetest ${OPENSSL_LIBS})
 add_test(igetest igetest)
 
 # keypairtest
 add_executable(keypairtest keypairtest.c)
-target_link_libraries(keypairtest ${TESTS_LIBS})
+target_link_libraries(keypairtest ${OPENSSL_LIBS})
 add_test(keypairtest keypairtest
 	${CMAKE_CURRENT_SOURCE_DIR}/ca.pem
 	${CMAKE_CURRENT_SOURCE_DIR}/server.pem
@@ -226,23 +214,23 @@ add_test(keypairtest keypairtest
 
 # md4test
 add_executable(md4test md4test.c)
-target_link_libraries(md4test ${TESTS_LIBS})
+target_link_libraries(md4test ${OPENSSL_LIBS})
 add_test(md4test md4test)
 
 # md5test
 add_executable(md5test md5test.c)
-target_link_libraries(md5test ${TESTS_LIBS})
+target_link_libraries(md5test ${OPENSSL_LIBS})
 add_test(md5test md5test)
 
 # mont
 add_executable(mont mont.c)
-target_link_libraries(mont ${TESTS_LIBS})
+target_link_libraries(mont ${OPENSSL_LIBS})
 add_test(mont mont)
 
 # ocsp_test
 if(ENABLE_EXTRATESTS)
 	add_executable(ocsp_test ocsp_test.c)
-	target_link_libraries(ocsp_test ${TESTS_LIBS})
+	target_link_libraries(ocsp_test ${OPENSSL_LIBS})
 	if(NOT MSVC)
 		add_test(NAME ocsptest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ocsptest.sh)
 	else()
@@ -252,12 +240,12 @@ endif()
 
 # optionstest
 add_executable(optionstest optionstest.c)
-target_link_libraries(optionstest ${TESTS_LIBS})
+target_link_libraries(optionstest ${OPENSSL_LIBS})
 add_test(optionstest optionstest)
 
 # pbkdf2
 add_executable(pbkdf2 pbkdf2.c)
-target_link_libraries(pbkdf2 ${TESTS_LIBS})
+target_link_libraries(pbkdf2 ${OPENSSL_LIBS})
 add_test(pbkdf2 pbkdf2)
 
 # pidwraptest
@@ -265,23 +253,23 @@ add_test(pbkdf2 pbkdf2)
 # awkward on systems with slow fork
 if(ENABLE_EXTRATESTS AND NOT MSVC)
 	add_executable(pidwraptest pidwraptest.c)
-	target_link_libraries(pidwraptest ${TESTS_LIBS})
+	target_link_libraries(pidwraptest ${OPENSSL_LIBS})
 	add_test(pidwraptest ${CMAKE_CURRENT_SOURCE_DIR}/pidwraptest.sh)
 endif()
 
 # pkcs7test
 add_executable(pkcs7test pkcs7test.c)
-target_link_libraries(pkcs7test ${TESTS_LIBS})
+target_link_libraries(pkcs7test ${OPENSSL_LIBS})
 add_test(pkcs7test pkcs7test)
 
 # poly1305test
 add_executable(poly1305test poly1305test.c)
-target_link_libraries(poly1305test ${TESTS_LIBS})
+target_link_libraries(poly1305test ${OPENSSL_LIBS})
 add_test(poly1305test poly1305test)
 
 # pq_test
 add_executable(pq_test pq_test.c)
-target_link_libraries(pq_test ${TESTS_LIBS})
+target_link_libraries(pq_test ${OPENSSL_LIBS})
 if(NOT MSVC)
 	add_test(NAME pq_test COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/pq_test.sh)
 else()
@@ -291,22 +279,22 @@ set_tests_properties(pq_test PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
 
 # randtest
 add_executable(randtest randtest.c)
-target_link_libraries(randtest ${TESTS_LIBS})
+target_link_libraries(randtest ${OPENSSL_LIBS})
 add_test(randtest randtest)
 
 # rc2test
 add_executable(rc2test rc2test.c)
-target_link_libraries(rc2test ${TESTS_LIBS})
+target_link_libraries(rc2test ${OPENSSL_LIBS})
 add_test(rc2test rc2test)
 
 # rc4test
 add_executable(rc4test rc4test.c)
-target_link_libraries(rc4test ${TESTS_LIBS})
+target_link_libraries(rc4test ${OPENSSL_LIBS})
 add_test(rc4test rc4test)
 
 # rfc5280time
 add_executable(rfc5280time rfc5280time.c)
-target_link_libraries(rfc5280time ${TESTS_LIBS})
+target_link_libraries(rfc5280time ${OPENSSL_LIBS})
 if(SMALL_TIME_T)
 	add_test(rfc5280time ${CMAKE_CURRENT_SOURCE_DIR}/rfc5280time_small.test)
 else()
@@ -315,17 +303,17 @@ endif()
 
 # rmdtest
 add_executable(rmdtest rmdtest.c)
-target_link_libraries(rmdtest ${TESTS_LIBS})
+target_link_libraries(rmdtest ${OPENSSL_LIBS})
 add_test(rmdtest rmdtest)
 
 # rsa_test
 add_executable(rsa_test rsa_test.c)
-target_link_libraries(rsa_test ${TESTS_LIBS})
+target_link_libraries(rsa_test ${OPENSSL_LIBS})
 add_test(rsa_test rsa_test)
 
 # servertest
 add_executable(servertest servertest.c)
-target_link_libraries(servertest ${TESTS_LIBS})
+target_link_libraries(servertest ${OPENSSL_LIBS})
 if(NOT MSVC)
 	add_test(NAME servertest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/servertest.sh)
 else()
@@ -335,27 +323,27 @@ set_tests_properties(servertest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR
 
 # sha1test
 add_executable(sha1test sha1test.c)
-target_link_libraries(sha1test ${TESTS_LIBS})
+target_link_libraries(sha1test ${OPENSSL_LIBS})
 add_test(sha1test sha1test)
 
 # sha256test
 add_executable(sha256test sha256test.c)
-target_link_libraries(sha256test ${TESTS_LIBS})
+target_link_libraries(sha256test ${OPENSSL_LIBS})
 add_test(sha256test sha256test)
 
 # sha512test
 add_executable(sha512test sha512test.c)
-target_link_libraries(sha512test ${TESTS_LIBS})
+target_link_libraries(sha512test ${OPENSSL_LIBS})
 add_test(sha512test sha512test)
 
 # ssl_versions
 add_executable(ssl_versions ssl_versions.c)
-target_link_libraries(ssl_versions ${TESTS_LIBS})
+target_link_libraries(ssl_versions ${OPENSSL_LIBS})
 add_test(ssl_versions ssl_versions)
 
 # ssltest
 add_executable(ssltest ssltest.c)
-target_link_libraries(ssltest ${TESTS_LIBS})
+target_link_libraries(ssltest ${OPENSSL_LIBS})
 if(NOT MSVC)
 	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
 else()
@@ -389,12 +377,12 @@ set_tests_properties(testrsa PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
 
 # timingsafe
 add_executable(timingsafe timingsafe.c)
-target_link_libraries(timingsafe ${TESTS_LIBS})
+target_link_libraries(timingsafe ${OPENSSL_LIBS})
 add_test(timingsafe timingsafe)
 
 # tlsexttest
 add_executable(tlsexttest tlsexttest.c)
-target_link_libraries(tlsexttest ${TESTS_LIBS})
+target_link_libraries(tlsexttest ${OPENSSL_LIBS})
 add_test(tlsexttest tlsexttest)
 
 # tlstest
@@ -407,7 +395,7 @@ else()
 endif()
 
 add_executable(tlstest ${TLSTEST_SRC})
-target_link_libraries(tlstest ${TESTS_LIBS})
+target_link_libraries(tlstest ${OPENSSL_LIBS})
 if(NOT MSVC)
 	add_test(NAME tlstest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.sh)
 else()
@@ -417,35 +405,35 @@ set_tests_properties(tlstest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
 
 # tls_ext_alpn
 add_executable(tls_ext_alpn tls_ext_alpn.c)
-target_link_libraries(tls_ext_alpn ${TESTS_LIBS})
+target_link_libraries(tls_ext_alpn ${OPENSSL_LIBS})
 add_test(tls_ext_alpn tls_ext_alpn)
 
 # tls_prf
 add_executable(tls_prf tls_prf.c)
-target_link_libraries(tls_prf ${TESTS_LIBS})
+target_link_libraries(tls_prf ${OPENSSL_LIBS})
 add_test(tls_prf tls_prf)
 
 # utf8test
 add_executable(utf8test utf8test.c)
-target_link_libraries(utf8test ${TESTS_LIBS})
+target_link_libraries(utf8test ${OPENSSL_LIBS})
 add_test(utf8test utf8test)
 
 # verifytest
 add_executable(verifytest verifytest.c)
-target_link_libraries(verifytest tls ${TESTS_LIBS})
+target_link_libraries(verifytest tls ${OPENSSL_LIBS})
 add_test(verifytest verifytest)
 
 # x25519test
 add_executable(x25519test x25519test.c)
-target_link_libraries(x25519test ${TESTS_LIBS})
+target_link_libraries(x25519test ${OPENSSL_LIBS})
 add_test(x25519test x25519test)
 
-if(ENABLE_VSTEST AND USE_SHARED)
+if(ENABLE_VSTEST AND BUILD_SHARED_LIBS)
 	add_custom_command(TARGET x25519test POST_BUILD
 		COMMAND "${CMAKE_COMMAND}" -E copy
-		"$<TARGET_FILE:tls-shared>"
-		"$<TARGET_FILE:ssl-shared>"
-		"$<TARGET_FILE:crypto-shared>"
+		"$<TARGET_FILE:tls>"
+		"$<TARGET_FILE:ssl>"
+		"$<TARGET_FILE:crypto>"
 		"${CMAKE_CURRENT_BINARY_DIR}"
 		COMMENT "Copying DLLs for regression tests")
 endif()

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -36,30 +36,24 @@ else()
 	add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
 endif()
 
-add_library(tls-objects OBJECT ${TLS_SRC})
-set(TLS_LIBRARIES tls)
-if (BUILD_SHARED)
-	list(APPEND TLS_LIBRARIES tls-shared)
-	add_library(tls STATIC $<TARGET_OBJECTS:tls-objects>)
-	add_library(tls-shared SHARED $<TARGET_OBJECTS:tls-objects>)
-	export_symbol(tls-shared ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym)
-	target_link_libraries(tls-shared ssl-shared crypto-shared)
+add_library(tls ${TLS_SRC})
+if (BUILD_SHARED_LIBS)
+	export_symbol(tls ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym)
+	target_link_libraries(tls ssl crypto)
 	if (WIN32)
-		target_link_libraries(tls-shared Ws2_32.lib)
+		target_link_libraries(tls Ws2_32.lib)
 		set(TLS_POSTFIX -${TLS_MAJOR_VERSION})
 	endif()
-	set_target_properties(tls-shared PROPERTIES
+	set_target_properties(tls PROPERTIES
 		OUTPUT_NAME tls${TLS_POSTFIX}
 		ARCHIVE_OUTPUT_NAME tls${TLS_POSTFIX})
-	set_target_properties(tls-shared PROPERTIES VERSION ${TLS_VERSION}
+	set_target_properties(tls PROPERTIES VERSION ${TLS_VERSION}
 		SOVERSION ${TLS_MAJOR_VERSION})
-else()
-	add_library(tls STATIC ${TLS_SRC})
 endif()
 
 if(ENABLE_LIBRESSL_INSTALL)
 	install(
-		TARGETS ${TLS_LIBRARIES}
+		TARGETS tls
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Removes custom logic for shared libraries and instead uses [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/v3.11/variable/BUILD_SHARED_LIBS.html) which is available in 2.8.8.