### PR TITLE
Turn off ssltest on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,4 @@ build_script:
   - cmake --build . --config %CONFIG%
 
 test_script:
-  - ctest -C %CONFIG%
+  - ctest -C %CONFIG% --timeout 150 --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,5 @@ build_script:
   - cmake --build . --config %CONFIG%
 
 test_script:
-  - ctest -C %CONFIG% --timeout 150 --output-on-failure
+  # TODO: Determine how to run ssltest on AppVeyor
+  - ctest -C %CONFIG% --timeout 150 --output-on-failure -E ssltest


### PR DESCRIPTION
On AppVeyor `ssltest` will not run so it should be turned off until it can be run successfully.