### PR TITLE
Suppress "overriding WinCrypt defines" warnings

### DIFF
--- a/patches/windows_headers.patch
+++ b/patches/windows_headers.patch
@@ -81,7 +81,7 @@ diff -u include/openssl.orig/x509.h include/openssl/x509.h
  extern "C" {
  #endif
 
-+#if defined(_WIN32)
++#if defined(_WIN32) && defined(__WINCRYPT_H__)
 +#ifndef LIBRESSL_INTERNAL
 +#ifdef _MSC_VER
 +#pragma message("Warning, overriding WinCrypt defines")


### PR DESCRIPTION
Suppress "overriding WinCrypt defines" from openssl/x509.h by defining `NOCRYPT`.
Only this file does not check `__WINCRYPT_H__` macro like other headers, since
https://github.com/libressl-portable/portable/commit/5d8a1cf7155130bd8101090d7e1d0c2f90d9b123#diff-74b6370bc092dd2988ab577b2eaa21dcR7