### PR TITLE
Add portable scaffold for SM3

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -424,6 +424,7 @@ set(
 	evp/m_sha1.c
 	evp/m_sigver.c
 	evp/m_streebog.c
+	evp/m_sm3.c
 	evp/m_wp.c
 	evp/names.c
 	evp/p5_crpt.c
@@ -558,6 +559,7 @@ set(
 	sha/sha1dgst.c
 	sha/sha256.c
 	sha/sha512.c
+	sm3/sm3.c
 	stack/stack.c
 	ts/ts_asn1.c
 	ts/ts_conf.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -614,6 +614,7 @@ libcrypto_la_SOURCES += evp/m_ripemd.c
 libcrypto_la_SOURCES += evp/m_sha1.c
 libcrypto_la_SOURCES += evp/m_sigver.c
 libcrypto_la_SOURCES += evp/m_streebog.c
+libcrypto_la_SOURCES += evp/m_sm3.c
 libcrypto_la_SOURCES += evp/m_wp.c
 libcrypto_la_SOURCES += evp/names.c
 libcrypto_la_SOURCES += evp/p5_crpt.c
@@ -805,6 +806,10 @@ libcrypto_la_SOURCES += sha/sha1dgst.c
 libcrypto_la_SOURCES += sha/sha256.c
 libcrypto_la_SOURCES += sha/sha512.c
 noinst_HEADERS += sha/sha_locl.h
+
+# sm3
+libcrypto_la_SOURCES += sm3/sm3.c
+noinst_HEADERS += sm3/sm3_locl.h
 
 # stack
 libcrypto_la_SOURCES += stack/stack.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -358,6 +358,11 @@ add_executable(sha512test sha512test.c)
 target_link_libraries(sha512test ${OPENSSL_LIBS})
 add_test(sha512test sha512test)
 
+# sm3test
+add_executable(sm3test sm3test.c)
+target_link_libraries(sm3test ${OPENSSL_LIBS})
+add_test(sm3test sm3test)
+
 # ssl_versions
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(ssl_versions ssl_versions.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -347,6 +347,11 @@ TESTS += sha512test
 check_PROGRAMS += sha512test
 sha512test_SOURCES = sha512test.c
 
+# sm3test
+TESTS += sm3test
+check_PROGRAMS += sm3test
+sm3test_SOURCES = sm3test.c
+
 # ssl_versions
 TESTS += ssl_versions
 check_PROGRAMS += ssl_versions

--- a/update.sh
+++ b/update.sh
@@ -132,7 +132,7 @@ copy_hdrs $libcrypto_src "stack/stack.h lhash/lhash.h stack/safestack.h
 	dsa/dsa.h engine/engine.h ui/ui.h pkcs12/pkcs12.h ts/ts.h
 	md4/md4.h ripemd/ripemd.h whrlpool/whrlpool.h idea/idea.h
 	rc2/rc2.h rc4/rc4.h ui/ui_compat.h txt_db/txt_db.h
-	chacha/chacha.h evp/evp.h poly1305/poly1305.h camellia/camellia.h
+	sm3/sm3.h chacha/chacha.h evp/evp.h poly1305/poly1305.h camellia/camellia.h
 	gost/gost.h curve25519/curve25519.h"
 
 copy_hdrs $libssl_src "srtp.h ssl.h ssl2.h ssl3.h ssl23.h tls1.h dtls1.h"


### PR DESCRIPTION
This is the companion to https://github.com/libressl-portable/openbsd/pull/98 adding support for SM3 hash function.

CC @ronaldtse