### PR TITLE
adjust Windows locks for auto-initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ include/openssl/*.h
 !/apps/openssl/apps_win.c
 !/apps/openssl/certhash_win.c
 
+/crypto/*
 !/crypto/Makefile.am.*
 !/crypto/compat/arc4random.h
 !/crypto/compat/b_win.c
@@ -156,8 +157,8 @@ include/openssl/*.h
 !/crypto/compat/bsd_asprintf.c
 !/crypto/compat/timegm.c
 !/crypto/compat/ui_openssl_win.c
+!/crypto/compat/crypto_lock_win.c
 !/crypto/CMakeLists.txt
-/crypto
 
 !/libtls-standalone/compat/Makefile.am
 /libtls-standalone/include/*.h

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -669,7 +669,7 @@ if(UNIX)
 endif()
 
 if(WIN32)
-	set(CRYPTO_SRC ${CRYPTO_SRC} crypto_lock_win.c)
+	set(CRYPTO_SRC ${CRYPTO_SRC} compat/crypto_lock_win.c)
 	set(CRYPTO_SRC ${CRYPTO_SRC} bio/b_win.c)
 	set(CRYPTO_UNEXPORT ${CRYPTO_UNEXPORT} BIO_s_log)
 	set(CRYPTO_SRC ${CRYPTO_SRC} ui/ui_openssl_win.c)

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -216,7 +216,7 @@ libcrypto_la_SOURCES += crypto_init.c
 if !HOST_WIN
 libcrypto_la_SOURCES += crypto_lock.c
 else
-libcrypto_la_SOURCES += crypto_lock_win.c
+libcrypto_la_SOURCES += compat/crypto_lock_win.c
 endif
 libcrypto_la_SOURCES += cversion.c
 libcrypto_la_SOURCES += ex_data.c

--- a/update.sh
+++ b/update.sh
@@ -154,7 +154,6 @@ for i in `awk '/SOURCES|HEADERS/ { print $3 }' crypto/Makefile.am` ; do
 	fi
 done
 $CP crypto/compat/b_win.c crypto/bio
-$CP crypto/compat/crypto_lock_win.c crypto
 $CP crypto/compat/ui_openssl_win.c crypto/ui
 # add the libcrypto symbol export list
 $GREP -v OPENSSL_ia32cap_P $libcrypto_src/Symbols.list | $GREP '^[A-Za-z0-9_]' > crypto/crypto.sym


### PR DESCRIPTION
This is a modification of #477 from @johnex that uses an atomic swap to perform initialization as-needed. This is the same as how arc4random lock initialization works in arc4random_win.h

Fixes #478