### PR TITLE
enable getpagesize for all Windows builds

### DIFF
--- a/crypto/compat/getpagesize.c
+++ b/crypto/compat/getpagesize.c
@@ -2,13 +2,13 @@
 
 #include <unistd.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
 int
 getpagesize(void) {
-#ifdef _MSC_VER
+#ifdef _WIN32
 	SYSTEM_INFO system_info;
 	GetSystemInfo(&system_info);
 	return system_info.dwPageSize;


### PR DESCRIPTION
Fix #479. We added stricter checks for getpagesize existing in #475, which check that there is an actual header definition. mingw-w64 appears to export getpagesize as a symbol, but it does not expose the header, so depending on how we configure it, we may not detect mingw's implementation of getpagesize. This switches the check in the headers to work for Visual Studio or mingw-w64 by building the Windows path on any Windows platform.