### PR TITLE
add stdint.h shim, include limits for SIZE_MAX on Android

### DIFF
--- a/include/compat/stdint.h
+++ b/include/compat/stdint.h
@@ -1,0 +1,19 @@
+/*
+ * Public domain
+ * stdint.h compatibility shim
+ */
+
+#ifdef _MSC_VER
+#include <../include/stdint.h>
+#else
+#include_next <stdint.h>
+#endif
+
+#ifndef LIBCRYPTOCOMPAT_STDINT_H
+#define LIBCRYPTOCOMPAT_STDINT_H
+
+#ifndef SIZE_MAX
+#include <limits.h>
+#endif
+
+#endif


### PR DESCRIPTION
This adds a workaround shim for some Android SDKs where SIZE_MAX is defined in limits.h instead of stdint.h.

See #482, this is a speculative diff, I haven't tested it.