### PR TITLE
Add ARM build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,16 @@ matrix:
       env: ARCH=mingw64
       dist: trusty
       sudo: required
+    - compiler: gcc
+      os: linux
+      env: ARCH=arm32
+      dist: trusty
+      sudo: required
+    - compiler: gcc
+      os: linux
+      env: ARCH=arm64
+      dist: trusty
+      sudo: required
 
 script:
   "./scripts/travis"

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -226,6 +226,7 @@ libcrypto_la_SOURCES += mem_dbg.c
 libcrypto_la_SOURCES += o_init.c
 libcrypto_la_SOURCES += o_str.c
 libcrypto_la_SOURCES += o_time.c
+noinst_HEADERS += arm_arch.h
 noinst_HEADERS += constant_time_locl.h
 noinst_HEADERS += cryptlib.h
 noinst_HEADERS += md32_common.h

--- a/scripts/travis
+++ b/scripts/travis
@@ -40,7 +40,8 @@ if [ "x$ARCH" = "xnative" ]; then
 		ninja
 		ninja test
 	fi
-else
+
+elif [ "x$ARCH" = "xmingw32" -o "x$ARCH" = "xmingw64" ]; then
 	sudo apt-get update
 	sudo apt-get install -y cmake ninja-build
 
@@ -73,4 +74,25 @@ else
 	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake -DBUILD_SHARED_LIBS=ON ..
 	 ninja
 	)
+
+elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then
+	sudo apt-get update
+	sudo apt-get install -y qemu-user-static binfmt-support
+
+	if [ "x$ARCH" = "xarm32" ]; then
+		sudo apt-get install -y g++-arm-linux-gnueabihf
+		sudo ln -s /usr/arm-linux-gnueabihf/lib /lib/arm-linux-gnueabihf
+		sudo ln -s /lib/arm-linux-gnueabihf/ld-2.19.so /lib/ld-linux-armhf.so.3
+		export CC=arm-linux-gnueabihf-gcc
+		./configure --host=arm-linux
+	else
+		sudo apt-get install -y g++-aarch64-linux-gnu
+		sudo ln -s /usr/aarch64-linux-gnu/lib/ /lib/aarch64-linux-gnu
+		sudo ln -s /lib/aarch64-linux-gnu/ld-2.19.so /lib/ld-linux-aarch64.so.1
+		export CC=aarch64-linux-gnu-gcc
+		./configure --host=aarch64-linux
+	fi
+
+	make -j 4 check
+	file apps/openssl/.libs/openssl
 fi


### PR DESCRIPTION
This PR adds ARM32 and ARM64 build by Travis-CI.
Regression tests are executed under QEMU.
Include ARM header file within distribution package.