### PR TITLE
Add Android build for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,91 @@ matrix:
       env: ARCH=arm64
       dist: trusty
       sudo: required
+    - language: android
+      name: "Android 4.x"
+      env: ARCH=android MIN_NAL=14 MAX_NAL=20
+      dist: trusty
+      sudo: required
+      android:
+        components:
+          - tools
+          - tools
+          - platform-tools
+          - build-tools-27.0.3
+          - android-27
+          - extra-google-m2repository
+          - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+    - language: android
+      name: "Android 5.x"
+      env: ARCH=android MIN_NAL=21 MAX_NAL=22
+      dist: trusty
+      sudo: required
+      android:
+        components:
+          - tools
+          - tools
+          - platform-tools
+          - build-tools-27.0.3
+          - android-27
+          - extra-google-m2repository
+          - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+    - language: android
+      name: "Android 6.x 7.x"
+      env: ARCH=android MIN_NAL=23 MAX_NAL=25
+      dist: trusty
+      sudo: required
+      android:
+        components:
+          - tools
+          - tools
+          - platform-tools
+          - build-tools-27.0.3
+          - android-27
+          - extra-google-m2repository
+          - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+    - language: android
+      name: "Android 8.x"
+      env: ARCH=android MIN_NAL=26 MAX_NAL=27
+      dist: trusty
+      sudo: required
+      android:
+        components:
+          - tools
+          - tools
+          - platform-tools
+          - build-tools-27.0.3
+          - android-27
+          - extra-google-m2repository
+          - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
+    - language: android
+      name: "Android 9.x"
+      env: ARCH=android MIN_NAL=28 MAX_NAL=28
+      dist: trusty
+      sudo: required
+      android:
+        components:
+          - tools
+          - tools
+          - platform-tools
+          - build-tools-27.0.3
+          - android-27
+          - extra-google-m2repository
+          - extra-android-m2repository
+      licenses:
+        - 'android-sdk-preview-license-.+'
+        - 'android-sdk-license-.+'
 
 script:
   "./scripts/travis"

--- a/scripts/travis
+++ b/scripts/travis
@@ -95,4 +95,65 @@ elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then
 
 	make -j 4 check
 	file apps/openssl/.libs/openssl
+
+elif [ "x$ARCH" = "xandroid" ]; then
+	echo y | sdkmanager 'ndk-bundle'
+	echo y | sdkmanager 'cmake;3.6.4111459'
+	echo y | sdkmanager 'lldb;3.0'
+	echo y | sdkmanager --update
+	echo y | sdkmanager --licenses
+
+	export CMAKE=$ANDROID_HOME/cmake/3.6.4111459/bin/cmake
+	export NINJA=$ANDROID_HOME/cmake/3.6.4111459/bin/ninja
+	export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+	export TC_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
+
+	# get available API level and architecture
+	pdir=$ANDROID_NDK_HOME/platforms
+	level_arch=""
+	level=$MIN_NAL
+	while [ $level -le $MAX_NAL ]
+	do
+		if [ -d $pdir/android-$level ] ; then
+			adir=$pdir/android-$level
+			if [ -d $adir/arch-arm ] ; then
+				level_arch="$level_arch $level;armeabi-v7a"
+			fi
+			if [ -d $adir/arch-arm64 ] ; then
+				level_arch="$level_arch $level;arm64-v8a"
+			fi
+			if [ -d $adir/arch-x86 ] ; then
+				level_arch="$level_arch $level;x86"
+			fi
+			if [ -d $adir/arch-x86_64 ] ; then
+				level_arch="$level_arch $level;x86_64"
+			fi
+		fi
+		level=`expr $level + 1`
+	done
+
+	# build each API level and architecture
+	for la in $level_arch
+	do
+		NAL=`echo $la | cut -d ';' -f 1`
+		ABI=`echo $la | cut -d ';' -f 2`
+		echo ""
+		echo "##### Date: `date`, Native API level: $NAL, ABI: $ABI"
+
+		(
+		 build_dir=build_$NAL_$ABI
+		 rm -fr $build_dir
+		 mkdir $build_dir
+		 cd $build_dir
+		 $CMAKE -GNinja -DCMAKE_MAKE_PROGRAM=$NINJA \
+		 -DANDROID_NDK=$ANDROID_NDK_HOME \
+		 -DCMAKE_TOOLCHAIN_FILE=$TC_FILE \
+		 -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$NAPI ..
+
+		 $NINJA -j 4
+
+		 echo ""
+		 file apps/openssl/openssl
+		)
+	done
 fi


### PR DESCRIPTION
This PR is trial and adds Android Travis-CI build.

- Build all available API level, and architecture (armeabi-v7a, arm64-v8a, x86, x86_64)
- Grouping API level by Android release version
- Using cmake and ninja
- Without running regressions

So often Android build issues are posted, and I thought this might solve them.
But, now I feel this might be too much, and it takes long time to complete all.
I think some API level or architecture could be omitted.

Any thoughts ?