### PR TITLE
add configure-time check for timespecsub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,11 @@ if(HAVE_GETPAGESIZE)
 	add_definitions(-DHAVE_GETPAGESIZE)
 endif()
 
+check_symbol_exists(timespecsub sys/time.h HAVE_TIMESPECSUB)
+if(HAVE_TIMESPECSUB)
+	add_definitions(-DHAVE_TIMESPECSUB)
+endif()
+
 check_function_exists(timingsafe_bcmp HAVE_TIMINGSAFE_BCMP)
 if(HAVE_TIMINGSAFE_BCMP)
 	add_definitions(-DHAVE_TIMINGSAFE_BCMP)

--- a/include/compat/time.h
+++ b/include/compat/time.h
@@ -39,7 +39,11 @@ typedef int clockid_t;
 int clock_gettime(clockid_t clock_id, struct timespec *tp);
 #endif
 
-#ifndef timespecsub
+#ifdef timespecsub
+#define HAVE_TIMESPECSUB
+#endif
+
+#ifndef HAVE_TIMESPECSUB
 #define timespecsub(tsp, usp, vsp)                                      \
         do {                                                            \
                 (vsp)->tv_sec = (tsp)->tv_sec - (usp)->tv_sec;          \
@@ -50,6 +54,7 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp);
                 }                                                       \
         } while (0)
 #endif
+
 #endif
 
 #endif

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -22,7 +22,6 @@ AC_CACHE_CHECK([for getpagesize], ac_cv_func_getpagesize, [
 AM_CONDITIONAL([HAVE_ASPRINTF], [test "x$ac_cv_func_asprintf" = xyes])
 AM_CONDITIONAL([HAVE_FREEZERO], [test "x$ac_cv_func_freezero" = xyes])
 AM_CONDITIONAL([HAVE_GETPAGESIZE], [test "x$ac_cv_func_getpagesize" = xyes])
-AM_CONDITIONAL([HAVE_TIMESPECSUB], [test "x$ac_cv_func_timespecsub" = xyes])
 AM_CONDITIONAL([HAVE_MEMMEM], [test "x$ac_cv_func_memmem" = xyes])
 AM_CONDITIONAL([HAVE_READPASSPHRASE], [test "x$ac_cv_func_readpassphrase" = xyes])
 AM_CONDITIONAL([HAVE_REALLOCARRAY], [test "x$ac_cv_func_reallocarray" = xyes])

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -5,7 +5,7 @@ AC_CHECK_HEADERS([err.h readpassphrase.h])
 AC_CHECK_FUNCS([asprintf freezero memmem])
 AC_CHECK_FUNCS([readpassphrase reallocarray recallocarray])
 AC_CHECK_FUNCS([strlcat strlcpy strndup strnlen strsep strtonum])
-AC_CHECK_FUNCS([timegm _mkgmtime])
+AC_CHECK_FUNCS([timegm _mkgmtime timespecsub])
 AC_CACHE_CHECK([for getpagesize], ac_cv_func_getpagesize, [
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 // Since Android NDK v16 getpagesize is defined as inline inside unistd.h
@@ -22,6 +22,7 @@ AC_CACHE_CHECK([for getpagesize], ac_cv_func_getpagesize, [
 AM_CONDITIONAL([HAVE_ASPRINTF], [test "x$ac_cv_func_asprintf" = xyes])
 AM_CONDITIONAL([HAVE_FREEZERO], [test "x$ac_cv_func_freezero" = xyes])
 AM_CONDITIONAL([HAVE_GETPAGESIZE], [test "x$ac_cv_func_getpagesize" = xyes])
+AM_CONDITIONAL([HAVE_TIMESPECSUB], [test "x$ac_cv_func_timespecsub" = xyes])
 AM_CONDITIONAL([HAVE_MEMMEM], [test "x$ac_cv_func_memmem" = xyes])
 AM_CONDITIONAL([HAVE_READPASSPHRASE], [test "x$ac_cv_func_readpassphrase" = xyes])
 AM_CONDITIONAL([HAVE_REALLOCARRAY], [test "x$ac_cv_func_reallocarray" = xyes])


### PR DESCRIPTION
This should fix #494 by adding a configure-time check for timespecsub. Since this is more often a macro, it still includes a preprocessor check, which is more difficult to do with CMake than autoconf.