### PR TITLE
Add portable scaffold for SM4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@ LibreSSL Portable Release Notes:
 
 2.9.0 - Development release
 
+	* Added the SM4 block cipher from the Chinese standard GB/T 32907-2016.
+
 	* Fixed warnings about clock_gettime on Windows Visual Studio builds.
 
 	* Fixed CMake builds on systems where getpagesize is defined as an

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -525,6 +525,7 @@ set(
 	evp/e_rc2.c
 	evp/e_rc4.c
 	evp/e_rc4_hmac_md5.c
+	evp/e_sm4.c
 	evp/e_xcbc_d.c
 	evp/encode.c
 	evp/evp_aead.c
@@ -683,6 +684,7 @@ set(
 	sha/sha256.c
 	sha/sha512.c
 	sm3/sm3.c
+	sm4/sm4.c
 	stack/stack.c
 	ts/ts_asn1.c
 	ts/ts_conf.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -623,6 +623,7 @@ libcrypto_la_SOURCES += evp/e_old.c
 libcrypto_la_SOURCES += evp/e_rc2.c
 libcrypto_la_SOURCES += evp/e_rc4.c
 libcrypto_la_SOURCES += evp/e_rc4_hmac_md5.c
+libcrypto_la_SOURCES += evp/e_sm4.c
 libcrypto_la_SOURCES += evp/e_xcbc_d.c
 libcrypto_la_SOURCES += evp/encode.c
 libcrypto_la_SOURCES += evp/evp_aead.c
@@ -841,6 +842,9 @@ noinst_HEADERS += sha/sha_locl.h
 # sm3
 libcrypto_la_SOURCES += sm3/sm3.c
 noinst_HEADERS += sm3/sm3_locl.h
+
+# sm4
+libcrypto_la_SOURCES += sm4/sm4.c
 
 # stack
 libcrypto_la_SOURCES += stack/stack.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,11 @@ add_executable(sm3test sm3test.c)
 target_link_libraries(sm3test ${OPENSSL_LIBS})
 add_test(sm3test sm3test)
 
+# sm4test
+add_executable(sm4test sm4test.c)
+target_link_libraries(sm4test ${OPENSSL_LIBS})
+add_test(sm4test sm4test)
+
 # ssl_versions
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(ssl_versions ssl_versions.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -377,6 +377,11 @@ TESTS += sm3test
 check_PROGRAMS += sm3test
 sm3test_SOURCES = sm3test.c
 
+# sm4test
+TESTS += sm4test
+check_PROGRAMS += sm4test
+sm4test_SOURCES = sm4test.c
+
 # ssl_versions
 TESTS += ssl_versions
 check_PROGRAMS += ssl_versions

--- a/update.sh
+++ b/update.sh
@@ -132,8 +132,8 @@ copy_hdrs $libcrypto_src "stack/stack.h lhash/lhash.h stack/safestack.h
 	dsa/dsa.h engine/engine.h ui/ui.h pkcs12/pkcs12.h ts/ts.h
 	md4/md4.h ripemd/ripemd.h whrlpool/whrlpool.h idea/idea.h
 	rc2/rc2.h rc4/rc4.h ui/ui_compat.h txt_db/txt_db.h
-	sm3/sm3.h chacha/chacha.h evp/evp.h poly1305/poly1305.h camellia/camellia.h
-	gost/gost.h curve25519/curve25519.h"
+	sm3/sm3.h sm4/sm4.h chacha/chacha.h evp/evp.h poly1305/poly1305.h
+	camellia/camellia.h gost/gost.h curve25519/curve25519.h"
 
 copy_hdrs $libssl_src "srtp.h ssl.h ssl2.h ssl3.h ssl23.h tls1.h dtls1.h"
 


### PR DESCRIPTION
Here is the companion to https://github.com/libressl-portable/openbsd/pull/103.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).