### PR TITLE
Update portable to support SM2 algorithm

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@ LibreSSL Portable Release Notes:
 
 2.9.0 - Development release
 
+	* Added the SM2 public key algorithm from the Chinese standard GB/T 32918-2016.
+
 	* Added the SM4 block cipher from the Chinese standard GB/T 32907-2016.
 
 	* Fixed warnings about clock_gettime on Windows Visual Studio builds.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -683,6 +683,11 @@ set(
 	sha/sha1dgst.c
 	sha/sha256.c
 	sha/sha512.c
+	sm2/sm2_crypt
+	sm2/sm2_err.c
+	sm2/sm2_pmeth.c
+	sm2/sm2_sign.c
+	sm2/sm2_za.c
 	sm3/sm3.c
 	sm4/sm4.c
 	stack/stack.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -839,6 +839,13 @@ libcrypto_la_SOURCES += sha/sha256.c
 libcrypto_la_SOURCES += sha/sha512.c
 noinst_HEADERS += sha/sha_locl.h
 
+# sm2
+libcrypto_la_SOURCES += sm2/sm2_crypt.c
+libcrypto_la_SOURCES += sm2/sm2_err.c
+libcrypto_la_SOURCES += sm2/sm2_pmeth.c
+libcrypto_la_SOURCES += sm2/sm2_sign.c
+libcrypto_la_SOURCES += sm2/sm2_za.c
+
 # sm3
 libcrypto_la_SOURCES += sm3/sm3.c
 noinst_HEADERS += sm3/sm3_locl.h

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -845,6 +845,7 @@ libcrypto_la_SOURCES += sm2/sm2_err.c
 libcrypto_la_SOURCES += sm2/sm2_pmeth.c
 libcrypto_la_SOURCES += sm2/sm2_sign.c
 libcrypto_la_SOURCES += sm2/sm2_za.c
+noinst_HEADERS += sm2/sm2_locl.h
 
 # sm3
 libcrypto_la_SOURCES += sm3/sm3.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(
 	.
 	../crypto/modes
 	../crypto/asn1
+	../crypto/sm2
 	../ssl
 	../tls
 	../apps/openssl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -383,6 +383,15 @@ add_executable(sha512test sha512test.c)
 target_link_libraries(sha512test ${OPENSSL_LIBS})
 add_test(sha512test sha512test)
 
+# sm2test
+add_executable(sm2crypttest sm2crypttest.c)
+target_link_libraries(sm2crypttest ${OPENSSL_LIBS})
+add_test(sm2crypttest sm2crypttest)
+
+add_executable(sm2sigtest sm2sigtest.c)
+target_link_libraries(sm2sigtest ${OPENSSL_LIBS})
+add_test(sm2sigtest sm2sigtest)
+
 # sm3test
 add_executable(sm3test sm3test.c)
 target_link_libraries(sm3test ${OPENSSL_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -393,6 +393,10 @@ add_executable(sm2sigtest sm2sigtest.c)
 target_link_libraries(sm2sigtest ${OPENSSL_LIBS})
 add_test(sm2sigtest sm2sigtest)
 
+add_executable(sm2evptest sm2evptest.c)
+target_link_libraries(sm2evptest ${OPENSSL_LIBS})
+add_test(sm2evptest sm2evptest)
+
 # sm3test
 add_executable(sm3test sm3test.c)
 target_link_libraries(sm3test ${OPENSSL_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@ include $(top_srcdir)/Makefile.am.common
 
 AM_CPPFLAGS += -I $(top_srcdir)/crypto/modes
 AM_CPPFLAGS += -I $(top_srcdir)/crypto/asn1
+AM_CPPFLAGS += -I $(top_srcdir)/crypto/sm2
 AM_CPPFLAGS += -I $(top_srcdir)/ssl
 AM_CPPFLAGS += -I $(top_srcdir)/tls
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -372,6 +372,15 @@ TESTS += sha512test
 check_PROGRAMS += sha512test
 sha512test_SOURCES = sha512test.c
 
+# sm2test
+TESTS += sm2crypttest
+check_PROGRAMS += sm2crypttest
+sm2crypttest_SOURCES = sm2crypttest.c
+
+TESTS += sm2sigtest
+check_PROGRAMS += sm2sigtest
+sm2sigtest_SOURCES = sm2sigtest.c
+
 # sm3test
 TESTS += sm3test
 check_PROGRAMS += sm3test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -382,6 +382,10 @@ TESTS += sm2sigtest
 check_PROGRAMS += sm2sigtest
 sm2sigtest_SOURCES = sm2sigtest.c
 
+TESTS += sm2evptest
+check_PROGRAMS += sm2evptest
+sm2evptest_SOURCES = sm2evptest.c
+
 # sm3test
 TESTS += sm3test
 check_PROGRAMS += sm3test

--- a/update.sh
+++ b/update.sh
@@ -132,7 +132,7 @@ copy_hdrs $libcrypto_src "stack/stack.h lhash/lhash.h stack/safestack.h
 	dsa/dsa.h engine/engine.h ui/ui.h pkcs12/pkcs12.h ts/ts.h
 	md4/md4.h ripemd/ripemd.h whrlpool/whrlpool.h idea/idea.h
 	rc2/rc2.h rc4/rc4.h ui/ui_compat.h txt_db/txt_db.h
-	sm3/sm3.h sm4/sm4.h chacha/chacha.h evp/evp.h poly1305/poly1305.h
+	sm2/sm2.h sm3/sm3.h sm4/sm4.h chacha/chacha.h evp/evp.h poly1305/poly1305.h
 	camellia/camellia.h gost/gost.h curve25519/curve25519.h"
 
 copy_hdrs $libssl_src "srtp.h ssl.h ssl2.h ssl3.h ssl23.h tls1.h dtls1.h"


### PR DESCRIPTION
This is the companion PR to libressl-portable/openbsd#105.

This is a contribution from Ribose Inc (@riboseinc).

cc @ronaldtse