### PR TITLE
Fix MacOSX cmake missing symbol _clock_gettime

### DIFF
--- a/apps/openssl/CMakeLists.txt
+++ b/apps/openssl/CMakeLists.txt
@@ -67,6 +67,13 @@ else()
 	set(OPENSSL_SRC ${OPENSSL_SRC} compat/strtonum.c)
 endif()
 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+        check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+        if(NOT HAVE_CLOCK_GETTIME)
+                set(OPENSSL_SRC ${OPENSSL_SRC} compat/clock_gettime_osx.c)
+        endif()
+endif()
+
 add_executable(openssl ${OPENSSL_SRC})
 target_include_directories(openssl PRIVATE . ../../include/compat)
 target_link_libraries(openssl ${OPENSSL_LIBS})


### PR DESCRIPTION
On El Capitan:
     [exec] [100%] Linking C executable openssl
     [exec] Undefined symbols for architecture x86_64:
     [exec]   "_clock_gettime", referenced from:
     [exec]       _app_timer_real in apps_posix.c.o
     [exec] ld: symbol(s) not found for architecture x86_64
     [exec] clang: error: linker command failed with exit code 1 (use -v to see invocation)
     [exec] make[2]: *** [apps/openssl/openssl] Error 1
     [exec] make[1]: *** [apps/openssl/CMakeFiles/openssl.dir/all] Error 2
     [exec] make: *** [all] Error 2