### PR TITLE
Fix getprogname_linux.c for Android API < 21

### DIFF
--- a/crypto/compat/getprogname_linux.c
+++ b/crypto/compat/getprogname_linux.c
@@ -5,5 +5,30 @@
 const char *
 getprogname(void)
 {
+	/*
+	 * Android added getprogname with API 21 [0]. We should not end up here
+	 * with APIs bigger than 21. Still write a precise check.
+	 *
+	 * Since Android is using portions of OpenBSD libc, it should have
+	 * a symbol called __progname [1].
+	 *
+	 * Regarding program_invocation_short_name, it is a GNU libc ext [2] and
+	 * so make it conditional to __GLIBC__ [3].
+	 *
+	 * .. [0] https://github.com/aosp-mirror/platform_bionic/blob/1eb6d3/libc/include/stdlib.h#L160
+	 *
+	 * .. [1] https://github.com/aosp-mirror/platform_bionic/commit/692207
+	 *
+	 * .. [2] https://linux.die.net/man/3/program_invocation_short_name
+	 *
+	 * .. [3] https://android.googlesource.com/platform/system/core/+/2819c0/base/logging.cpp#65
+	 */
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 21
+	extern const char *__progname;
+	return __progname;
+#elif defined(__GLIBC__)
 	return program_invocation_short_name;
+#else
+#error "Cannot emulate getprogname"
+#endif
 }


### PR DESCRIPTION
This diff fixes the build of LibreSSL for Android with API < 21 where
the `getprogname` system call was not part of libc.

A comment in the diff itself explains in detail the issue.

I'm submitting this diff after I did a full build of LibreSSL [1] and
other software we're using, plus smoke testing.

.. [1] https://github.com/measurement-kit/script-build-android/releases/tag/v0.10.2-1