### PR TITLE
Check for existing uninstall target before creating.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,10 +357,12 @@ if(NOT MSVC)
 		DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-configure_file(
-	"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-	IMMEDIATE @ONLY)
+if(NOT TARGET uninstall)
+	configure_file(
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+		IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+	add_custom_target(uninstall
+		COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()


### PR DESCRIPTION
Prevents LibreSSL from generating it's own uninstall target if one already exists. In big CMake projects there is usually one already defined and will cause a error similar to this:
```
1> [CMake] CMake Error at Build/x64-Debug/_deps/libressl-src/source/CMakeLists.txt:259 (add_custom_target):
1> [CMake]   add_custom_target cannot create target "uninstall" because another target
1> [CMake]   with the same name already exists.  The existing target is a custom target
1> [CMake]   created in source directory
```