### PR TITLE
Override the default path of cert.pem in libtls

### DIFF
--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -24,9 +24,9 @@ if(WIN32)
 endif()
 
 if(NOT "${OPENSSLDIR}" STREQUAL "")
-	add_definitions(-D_PATH_SSL_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+	add_definitions(-DTLS_DEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
 else()
-	add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
+	add_definitions(-DTLS_DEFAULT_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
 endif()
 
 add_library(tls ${TLS_SRC})

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -13,9 +13,9 @@ libtls_la_LIBADD += $(PLATFORM_LDADD)
 
 libtls_la_CPPFLAGS = $(AM_CPPFLAGS)
 if OPENSSLDIR_DEFINED
-libtls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
+libtls_la_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
 else
-libtls_la_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
+libtls_la_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
 endif
 
 libtls_la_SOURCES = tls.c


### PR DESCRIPTION
This PR is for issue https://github.com/libressl-portable/portable/issues/556 .
Refer to the commit https://github.com/libressl-portable/openbsd/commit/461e241c9b6c0a199a3f128d34ec82a7f2cc1cab , too.