### PR TITLE
Include FindPackageHandleStandardArgs before use.

### DIFF
--- a/FindLibreSSL.cmake
+++ b/FindLibreSSL.cmake
@@ -66,6 +66,8 @@ Set LIBRESSL_ROOT_DIR to the root directory of an LibreSSL installation.
 
 ]=======================================================================]
 
+INCLUDE(FindPackageHandleStandardArgs)
+
 # Set Hints
 set(_LIBRESSL_ROOT_HINTS
     ${LIBRESSL_ROOT_DIR}


### PR DESCRIPTION
The function 'FindPackageHandleStandardArgs' needs to be included before used.
Addresses Issue #559 
https://github.com/libressl-portable/portable/issues/559