### PR TITLE
crypto: do not include gost.h into noinst_HEADERS

### DIFF
--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -697,7 +697,6 @@ libcrypto_la_SOURCES += gost/gostr341001_params.c
 libcrypto_la_SOURCES += gost/gostr341001_pmeth.c
 libcrypto_la_SOURCES += gost/gostr341194.c
 libcrypto_la_SOURCES += gost/streebog.c
-noinst_HEADERS += gost/gost.h
 noinst_HEADERS += gost/gost_asn1.h
 noinst_HEADERS += gost/gost_locl.h
 


### PR DESCRIPTION
gost/gost.h will go into include/openssl/, no need to duplicate it into crypto/gost directory

Signed-by: Dmitry Baryshkov <dbaryshkov@gmail.com>