### PR TITLE
crypto: regenerate crypto_portable.sym

### DIFF
--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST += compat/strcasecmp.c
 BUILT_SOURCES = crypto_portable.sym
 CLEANFILES = crypto_portable.sym
 
-crypto_portable.sym:
+crypto_portable.sym: crypto.sym  Makefile
 	-echo "generating crypto_portable.sym ..."
 	-cp $(top_srcdir)/crypto/crypto.sym crypto_portable.sym
 	-chmod u+w crypto_portable.sym
@@ -94,6 +94,7 @@ if HOST_WIN
 endif
 
 libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym
+EXTRA_libcrypto_la_DEPENDENCIES = crypto_portable.sym
 libcrypto_la_LIBADD = libcompat.la
 if !HAVE_EXPLICIT_BZERO
 libcrypto_la_LIBADD += libcompatnoopt.la


### PR DESCRIPTION
Make crypto_portable.sym depend on crypto.sym and libcrypto.so on
crypto_portable.sym to rebuild library if one of symbol files changes.

Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>