### PR TITLE
Add support for use of static MSVC runtimes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.15)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckLibraryExists)
@@ -9,6 +9,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 include(cmake_export_symbol)
 include(GNUInstallDirs)
 
+cmake_policy(SET CMP0091 NEW)
 project (LibreSSL C ASM)
 
 enable_testing()
@@ -35,6 +36,11 @@ option(ENABLE_ASM "Enable assembly" ON)
 option(ENABLE_EXTRATESTS "Enable extra tests that may be unreliable on some platforms" OFF)
 option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
 set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
+
+option(USE_STATIC_MSVC_RUNTIMES "Use /MT instead of /MD in MSVC" OFF)
+if( USE_STATIC_MSVC_RUNTIMES )
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 if(NOT LIBRESSL_SKIP_INSTALL)
 	set( ENABLE_LIBRESSL_INSTALL ON )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required (VERSION 3.15.7)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckLibraryExists)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(MSVC)
 cmake_minimum_required (VERSION 3.16.4)
+cmake_policy(SET CMP0091 NEW)
 else()
 cmake_minimum_required (VERSION 3.0)
 endif()
@@ -13,7 +14,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 include(cmake_export_symbol)
 include(GNUInstallDirs)
 
-cmake_policy(SET CMP0091 NEW)
 project (LibreSSL C ASM)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
+if(MSVC)
 cmake_minimum_required (VERSION 3.16.4)
+else()
+cmake_minimum_required (VERSION 3.0)
+endif()
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckLibraryExists)
@@ -38,7 +42,7 @@ option(ENABLE_NC "Enable installing TLS-enabled nc(1)" OFF)
 set(OPENSSLDIR ${OPENSSLDIR} CACHE PATH "Set the default openssl directory" FORCE)
 
 option(USE_STATIC_MSVC_RUNTIMES "Use /MT instead of /MD in MSVC" OFF)
-if( USE_STATIC_MSVC_RUNTIMES )
+if(USE_STATIC_MSVC_RUNTIMES)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.15.7)
+cmake_minimum_required (VERSION 3.16.4)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckLibraryExists)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,22 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
-      ARCHITECTURE: Win64
+      ARCHITECTURE: Win32
       CONFIG: Release
       SHARED_LIBS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
-      ARCHITECTURE: Win64
+      ARCHITECTURE: Win32
+      CONFIG: Release
+      SHARED_LIBS: OFF
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
+      ARCHITECTURE: x64
+      CONFIG: Release
+      SHARED_LIBS: ON
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
+      ARCHITECTURE: x64
       CONFIG: Release
       SHARED_LIBS: OFF
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,24 @@
 image:
-  - Visual Studio 2015
-  #- Visual Studio 2017
+  - Visual Studio 2019
 
 environment:
   PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
 
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015 Win64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019 Win64
       CONFIG: Release
       SHARED_LIBS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
       CONFIG: Release
       SHARED_LIBS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015 Win64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019 Win64
       CONFIG: Release
       SHARED_LIBS: OFF
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
       CONFIG: Release
       SHARED_LIBS: OFF
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,19 +6,13 @@ environment:
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: Visual Studio 16 2019 Win64
+      GENERATOR: Visual Studio 16 2019
+      ARCHITECTURE: Win64
       CONFIG: Release
       SHARED_LIBS: ON
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
-      CONFIG: Release
-      SHARED_LIBS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: Visual Studio 16 2019 Win64
-      CONFIG: Release
-      SHARED_LIBS: OFF
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: Visual Studio 16 2019
+      ARCHITECTURE: Win64
       CONFIG: Release
       SHARED_LIBS: OFF
 
@@ -33,7 +27,7 @@ before_build:
   - bash autogen.sh
   - mkdir build
   - cd build
-  - cmake .. -G "%GENERATOR%" -DBUILD_SHARED_LIBS=%SHARED_LIBS% -DCMAKE_INSTALL_PREFIX=../local
+  - cmake .. -G "%GENERATOR%" -A "%ARCHITECTURE%" -DBUILD_SHARED_LIBS=%SHARED_LIBS% -DCMAKE_INSTALL_PREFIX=../local
 
 build_script:
   - cmake --build . --config %CONFIG%


### PR DESCRIPTION
In certain contexts LibreSSL needs to be built with `/MT` instead of `/MD` for inclusion in other projects. These changes allow for the command-line option `USE_STATIC_MSVC_RUNTIMES` to be set to `ON` if the use wishes to generate projects that will build with static runtimes.

This feature requires CMAKE version 3.15+, hence the minimum required version has changed as well.