### PR TITLE
avoid exporting a sleep() symbol from libcrypto

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -808,7 +808,6 @@ if(WIN32)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} posix_write)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} posix_getsockopt)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} posix_setsockopt)
-	set(EXTRA_EXPORT ${EXTRA_EXPORT} sleep)
 endif()
 
 if(NOT HAVE_ASPRINTF)

--- a/crypto/compat/posix_win.c
+++ b/crypto/compat/posix_win.c
@@ -242,10 +242,4 @@ int gettimeofday(struct timeval * tp, struct timezone * tzp)
 	return 0;
 }
 
-unsigned int sleep(unsigned int seconds)
-{
-	Sleep(seconds * 1000);
-	return seconds;
-}
-
 #endif

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -37,7 +37,13 @@ ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
 
 #define access _access
 
-unsigned int sleep(unsigned int seconds);
+#ifdef _MSC_VER
+static inline unsigned int sleep(unsigned int seconds)
+{
+       Sleep(seconds * 1000);
+       return seconds;
+}
+#endif
 
 int ftruncate(int fd, off_t length);
 uid_t getuid(void);

--- a/include/compat/unistd.h
+++ b/include/compat/unistd.h
@@ -38,6 +38,7 @@ ssize_t pwrite(int d, const void *buf, size_t nbytes, off_t offset);
 #define access _access
 
 #ifdef _MSC_VER
+#include <windows.h>
 static inline unsigned int sleep(unsigned int seconds)
 {
        Sleep(seconds * 1000);


### PR DESCRIPTION
Since it seems only MSVC lacks sleep(), and it's only used by apps, lets special-case that and make it available as a static inline function instead. This fixes linkage issues where the target app also defines a sleep() compatibility function.