### PR TITLE
[CMakeLists.txt] Move `project` below `cmake_minimum_required`;

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
 if(MSVC)
-cmake_minimum_required (VERSION 3.16.4)
-cmake_policy(SET CMP0091 NEW)
+	cmake_minimum_required (VERSION 3.16.4)
+	cmake_policy(SET CMP0091 NEW)
 else()
-cmake_minimum_required (VERSION 3.0)
+	cmake_minimum_required (VERSION 3.0)
 endif()
+
+project (LibreSSL C ASM)
+
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckLibraryExists)
@@ -13,8 +16,6 @@ include(CheckTypeSize)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 include(cmake_export_symbol)
 include(GNUInstallDirs)
-
-project (LibreSSL C ASM)
 
 enable_testing()
 

--- a/tap-driver.sh
+++ b/tap-driver.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Copyright (C) 2011-2018 Free Software Foundation, Inc.
+# Copyright (C) 2011-2020 Free Software Foundation, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
…also, fixed indentation in its `if`/`else` block; and in [tap-driver.sh] Updated copyright line (was automatic when I ran `./autogen.sh`)

The `CMakeLists.txt` reordering resolving this warning:
```
CMake Warning (dev) at /share/cmake/Modules/GNUInstallDirs.cmake:225 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
```