### PR TITLE
fix ssltest to run on appveyor, keep test log as artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,5 +43,4 @@ build_script:
   - cmake --build . --config %CONFIG%
 
 test_script:
-  # TODO: Determine how to run ssltest on AppVeyor
-  - ctest -C %CONFIG% --timeout 150 --output-on-failure -E ssltest
+  - ctest -C %CONFIG% --timeout 150 --output-on-failure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,3 +44,12 @@ build_script:
 
 test_script:
   - ctest -C %CONFIG% --timeout 150 --output-on-failure
+
+on_failure:
+  - 7z a Testing.zip Testing
+  - appveyor PushArtifact Testing.zip
+
+artifacts:
+  - path: build\Testing
+    name: Testing
+    type: zip

--- a/tests/testssl.bat
+++ b/tests/testssl.bat
@@ -11,7 +11,10 @@ set extra=%6
 
 %openssl% version & if !errorlevel! neq 0 exit /b 1
 
-for /f "usebackq" %%s in (`%openssl% x509 -in %cert% -text -noout ^| find /c "DSA Public Key"`) do set lines=%%s
+set lines=0
+for /f "usebackq" %%s in (`%openssl% x509 -in %cert% -text -noout ^| find "DSA Public Key"`) do (
+  set /a lines=%lines%+1
+)
 if %lines% gtr 0 (
   set dsa_cert=YES
 ) else (


### PR DESCRIPTION
Modify testssl.bat to run ssltest on appveyor.
It appears that some sort of batch file command freezes on appveyor.
And, I added another commit to keep testing log as an artifact, since it helps test failure investigation.
I separated these 2 changes into another commits respectively.
My main proposal is ssltest, and if keeping log is not good, I would like to drop that commit.