### PR TITLE
Add x509_verify.c x509_verify.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ tests/bnaddsub*
 tests/bn_rand_interval*
 tests/bn_to_string*
 tests/cipher*
+tests/constraints*
 tests/explicit_bzero*
 tests/freenull*
 tests/gost2814789t*
@@ -77,6 +78,9 @@ tests/*.pem
 tests/testssl
 tests/*.txt
 tests/compat/*.c
+tests/verify*
+tests/x509_info*
+tests/x509attribute*
 tests/x509name*
 !tests/optionstest.c
 !tests/*.test

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -769,6 +769,7 @@ set(
 	x509/x509_txt.c
 	x509/x509_utl.c
 	x509/x509_v3.c
+	x509/x509_verify.c
 	x509/x509_vfy.c
 	x509/x509_vpm.c
 	x509/x509cset.c

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -953,6 +953,7 @@ libcrypto_la_SOURCES += x509/x509_trs.c
 libcrypto_la_SOURCES += x509/x509_txt.c
 libcrypto_la_SOURCES += x509/x509_utl.c
 libcrypto_la_SOURCES += x509/x509_v3.c
+libcrypto_la_SOURCES += x509/x509_verify.c
 libcrypto_la_SOURCES += x509/x509_vfy.c
 libcrypto_la_SOURCES += x509/x509_vpm.c
 libcrypto_la_SOURCES += x509/x509cset.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -548,6 +548,11 @@ add_executable(x509attribute x509attribute.c)
 target_link_libraries(x509attribute ${OPENSSL_LIBS})
 add_test(x509attribute x509attribute)
 
+# x509_info
+add_executable(x509_info x509_info.c)
+target_link_libraries(x509_info ${OPENSSL_LIBS})
+add_test(x509_info x509_info)
+
 # x509name
 add_executable(x509name x509name.c)
 target_link_libraries(x509name ${OPENSSL_LIBS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,10 +124,12 @@ if(NOT BUILD_SHARED_LIBS)
 	add_test(cipher_list cipher_list)
 endif()
 
-# cipherstest
-add_executable(cipherstest cipherstest.c)
-target_link_libraries(cipherstest ${OPENSSL_LIBS})
-add_test(cipherstest cipherstest)
+if(NOT BUILD_SHARED_LIBS)
+	# cipherstest
+	add_executable(cipherstest cipherstest.c)
+	target_link_libraries(cipherstest ${OPENSSL_LIBS})
+	add_test(cipherstest cipherstest)
+endif()
 
 # clienttest
 # disabled

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -484,6 +484,11 @@ TESTS += x509attribute
 check_PROGRAMS += x509attribute
 x509attribute_SOURCES = x509attribute.c
 
+# x509_info
+TESTS += x509_info
+check_PROGRAMS += x509_info
+x509_info_SOURCES = x509_info.c
+
 # x509name
 TESTS += x509name
 check_PROGRAMS += x509name

--- a/update.sh
+++ b/update.sh
@@ -126,7 +126,7 @@ copy_hdrs $libcrypto_src "stack/stack.h lhash/lhash.h stack/safestack.h
 	objects/objects.h asn1/asn1.h bn/bn.h ec/ec.h ecdsa/ecdsa.h
 	ecdh/ecdh.h rsa/rsa.h sha/sha.h x509/x509_vfy.h pkcs7/pkcs7.h pem/pem.h
 	pem/pem2.h hkdf/hkdf.h hmac/hmac.h rand/rand.h md5/md5.h
-	x509/x509v3.h conf/conf.h ocsp/ocsp.h
+	x509/x509v3.h x509/x509_verify.h conf/conf.h ocsp/ocsp.h
 	aes/aes.h modes/modes.h asn1/asn1t.h dso/dso.h bf/blowfish.h
 	bio/bio.h cast/cast.h cmac/cmac.h cms/cms.h conf/conf_api.h des/des.h dh/dh.h
 	dsa/dsa.h engine/engine.h ui/ui.h pkcs12/pkcs12.h ts/ts.h


### PR DESCRIPTION
This PR is
- Add x509_verify.c x509_verify.h
- Restrict cipherstest with static build only in CMake, since it changes to use internal function
- Add regress x509_info.c
- Update .gitignore for some files in tests