### PR TITLE
Build fixes for static compatibility dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ include/openssl/*.h
 /apps/ocspcheck/ocspcheck*
 /apps/ocspcheck/compat/memmem.c
 /apps/ocspcheck/compat/inet_ntop.c
+/apps/ocspcheck/compat/strtonum.c
 
 /apps/nc/*.h
 /apps/nc/*.c

--- a/apps/nc/Makefile.am
+++ b/apps/nc/Makefile.am
@@ -1,5 +1,7 @@
 include $(top_srcdir)/Makefile.am.common
 
+-include $(abs_top_builddir)/crypto/libcrypto_la_objects.mk
+
 if BUILD_NC
 
 if ENABLE_NC
@@ -12,10 +14,12 @@ endif
 EXTRA_DIST = nc.1
 EXTRA_DIST += CMakeLists.txt
 
-nc_LDFLAGS = $(abs_top_builddir)/crypto/.libs/libcrypto.a
-
 nc_LDADD = $(abs_top_builddir)/tls/libtls.la
 nc_LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
+
+nc_LDADD += $(libcrypto_la_objects)
+nc_LDADD += $(libcompat_la_objects)
+nc_LDADD += $(libcompatnoopt_la_objects)
 
 AM_CPPFLAGS += -I$(top_srcdir)/apps/nc/compat
 

--- a/apps/ocspcheck/CMakeLists.txt
+++ b/apps/ocspcheck/CMakeLists.txt
@@ -13,6 +13,13 @@ else()
         set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/memmem.c)
 endif()
 
+check_function_exists(strtonum HAVE_STRTONUM)
+if(HAVE_STRTONUM)
+	add_definitions(-DHAVE_STRTONUM)
+else()
+	set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/strtonum.c)
+endif()
+
 if(NOT "${OPENSSLDIR}" STREQUAL "")
 	add_definitions(-DDEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
 else()

--- a/apps/ocspcheck/Makefile.am
+++ b/apps/ocspcheck/Makefile.am
@@ -19,3 +19,7 @@ noinst_HEADERS = http.h
 if !HAVE_MEMMEM
 ocspcheck_SOURCES += compat/memmem.c
 endif
+
+if !HAVE_STRTONUM
+ocspcheck_SOURCES += compat/strtonum.c
+endif

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -99,10 +99,10 @@ libcrypto_la_objects.mk: Makefile
 	  | sed 's/  */ $$\(abs_top_builddir\)\/crypto\//g' \
 	  > libcrypto_la_objects.mk
 	@echo "libcompat_la_objects= $(libcompat_la_OBJECTS)" \
-	  | sed 's/  */ $$\(abs_top_builddir\)\/crypto\//g' \
+	  | sed 's/compat\// $$\(abs_top_builddir\)\/crypto\/&/g' \
 	  >> libcrypto_la_objects.mk
 	@echo "libcompatnoopt_la_objects= $(libcompatnoopt_la_OBJECTS)" \
-	  | sed 's/  */ $$\(abs_top_builddir\)\/crypto\//g' \
+	  | sed 's/compat\// $$\(abs_top_builddir\)\/crypto\/&/g' \
 	  >> libcrypto_la_objects.mk
 
 libcrypto_la_LDFLAGS = -version-info @LIBCRYPTO_VERSION@ -no-undefined -export-symbols crypto_portable.sym

--- a/update.sh
+++ b/update.sh
@@ -254,6 +254,7 @@ echo "copying ocspcheck(1) source"
 $CP $sbin_src/ocspcheck/ocspcheck.8 apps/ocspcheck
 rm -f apps/ocspcheck/*.c apps/ocspcheck/*.h
 $CP_LIBC $libc_src/string/memmem.c apps/ocspcheck/compat
+$CP_LIBC $libc_src/stdlib/strtonum.c apps/ocspcheck/compat
 for i in `awk '/SOURCES|HEADERS|MANS/ { print $3 }' apps/ocspcheck/Makefile.am` ; do
 	if [ -e $sbin_src/ocspcheck/$i ]; then
 		$CP $sbin_src/ocspcheck/$i apps/ocspcheck


### PR DESCRIPTION
This fixes a couple of issues, one adding a strtonum dependency in check, and a fix for #626 where nc(1) is unconditionally linked to libcrypto.a, but it might not always be built.