### PR TITLE
Statically link libcrypto/ssl into libtls with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,8 @@ if(SIZEOF_TIME_T STREQUAL "4")
 endif()
 add_definitions(-DSIZEOF_TIME_T=${SIZEOF_TIME_T})
 
-set(OPENSSL_LIBS tls ssl crypto ${PLATFORM_LIBS})
+set(OPENSSL_LIBS ssl crypto ${PLATFORM_LIBS})
+set(LIBTLS_LIBS tls ${PLATFORM_LIBS})
 
 add_subdirectory(crypto)
 add_subdirectory(ssl)

--- a/apps/nc/CMakeLists.txt
+++ b/apps/nc/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 add_executable(nc ${NC_SRC})
 target_include_directories(nc PRIVATE . ./compat ../../include/compat)
-target_link_libraries(nc tls ${OPENSSL_LIBS})
+target_link_libraries(nc ${LIBTLS_LIBS})
 
 if(ENABLE_NC)
 	if(ENABLE_LIBRESSL_INSTALL)

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -968,7 +968,23 @@ if(EXTRA_EXPORT)
 	endforeach()
 endif()
 
-add_library(crypto ${CRYPTO_SRC})
+add_library(crypto_obj OBJECT ${CRYPTO_SRC})
+target_include_directories(crypto_obj
+	PRIVATE
+		.
+		asn1
+		bn
+		dsa
+		ec
+		ecdh
+		ecdsa
+		evp
+		modes
+		../include/compat
+	PUBLIC
+		../include)
+
+add_library(crypto $<TARGET_OBJECTS:crypto_obj>)
 target_include_directories(crypto
 	PRIVATE
 		.

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -968,6 +968,8 @@ if(EXTRA_EXPORT)
 	endforeach()
 endif()
 
+set(LIBTLS_EXTRA_EXPORT ${EXTRA_EXPORT} PARENT_SCOPE)
+
 add_library(crypto_obj OBJECT ${CRYPTO_SRC})
 target_include_directories(crypto_obj
 	PRIVATE

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -52,7 +52,15 @@ set(
 	tls13_server.c
 )
 
-add_library(ssl ${SSL_SRC})
+add_library(ssl_obj OBJECT ${SSL_SRC})
+target_include_directories(ssl_obj
+	PRIVATE
+		.
+		../include/compat
+	PUBLIC
+		../include)
+
+add_library(ssl $<TARGET_OBJECTS:ssl_obj>)
 target_include_directories(ssl
 	PRIVATE
 		.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,7 +144,7 @@ add_test(cmstest cmstest)
 
 # configtest
 add_executable(configtest configtest.c)
-target_link_libraries(configtest ${OPENSSL_LIBS})
+target_link_libraries(configtest ${LIBTLS_LIBS})
 add_test(configtest configtest)
 
 # constraints
@@ -276,7 +276,7 @@ if(NOT BUILD_SHARED_LIBS)
 	add_test(key_schedule key_schedule)
 
 	add_executable(keypairtest keypairtest.c)
-	target_link_libraries(keypairtest ${OPENSSL_LIBS})
+	target_link_libraries(keypairtest ${LIBTLS_LIBS})
 	add_test(keypairtest keypairtest
 		${CMAKE_CURRENT_SOURCE_DIR}/ca.pem
 		${CMAKE_CURRENT_SOURCE_DIR}/server.pem
@@ -502,7 +502,7 @@ else()
 endif()
 
 add_executable(tlstest ${TLSTEST_SRC})
-target_link_libraries(tlstest ${OPENSSL_LIBS})
+target_link_libraries(tlstest ${LIBTLS_LIBS})
 if(NOT MSVC)
 	add_test(NAME tlstest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tlstest.sh)
 else()
@@ -541,7 +541,7 @@ endif()
 # verifytest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(verifytest verifytest.c)
-	target_link_libraries(verifytest ${OPENSSL_LIBS})
+	target_link_libraries(verifytest ${LIBTLS_LIBS})
 	add_test(verifytest verifytest)
 endif()
 

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -29,7 +29,15 @@ else()
 	add_definitions(-DTLS_DEFAULT_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
 endif()
 
-add_library(tls ${TLS_SRC})
+add_library(tls_obj OBJECT ${TLS_SRC})
+target_include_directories(tls_obj
+	PRIVATE
+		.
+		../include/compat
+	PUBLIC
+		../include)
+
+add_library(tls $<TARGET_OBJECTS:tls_obj>)
 target_include_directories(tls
 	PRIVATE
 		.

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -29,6 +29,15 @@ else()
 	add_definitions(-DTLS_DEFAULT_CA_FILE=\"${CMAKE_INSTALL_PREFIX}/etc/ssl/cert.pem\")
 endif()
 
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym DESTINATION
+	${CMAKE_CURRENT_BINARY_DIR})
+if(LIBTLS_EXTRA_EXPORT)
+	list(SORT LIBTLS_EXTRA_EXPORT)
+	foreach(SYM IN LISTS LIBTLS_EXTRA_EXPORT)
+		file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/tls.sym "${SYM}\n")
+	endforeach()
+endif()
+
 add_library(tls_obj OBJECT ${TLS_SRC})
 target_include_directories(tls_obj
 	PRIVATE
@@ -37,7 +46,8 @@ target_include_directories(tls_obj
 	PUBLIC
 		../include)
 
-add_library(tls $<TARGET_OBJECTS:tls_obj>)
+add_library(tls $<TARGET_OBJECTS:tls_obj> $<TARGET_OBJECTS:ssl_obj>
+	$<TARGET_OBJECTS:crypto_obj>)
 target_include_directories(tls
 	PRIVATE
 		.
@@ -45,8 +55,8 @@ target_include_directories(tls
 	PUBLIC
 		../include)
 
-export_symbol(tls ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym)
-target_link_libraries(tls ssl crypto ${PLATFORM_LIBS})
+export_symbol(tls ${CMAKE_CURRENT_BINARY_DIR}/tls.sym)
+target_link_libraries(tls ${PLATFORM_LIBS})
 if (WIN32)
 	set(TLS_POSTFIX -${TLS_MAJOR_VERSION})
 endif()


### PR DESCRIPTION
This PR makes linking libcrypto and libssl to libtls statically with CMake build.

To enable this, applied cmake object library functionality to libcrypto, libssl, libtls, respectively, by first commit.
Cmake object library is a group of compiled object files, and it can be linked to generate shared/static library.

By second commit, libtls is generated by linking these cmake object libraries.
This libtls needs to export compat functions that currently exported from libcrypto.
To enable this, variable `EXTRA_EXPORT` is set to PARENT_SCOPE as `LIBTLS_EXTRA_EXPORT` and passed to tls/CMakeLists.txt.
`LIBTLS_EXTRA_EXPORT` is used to generate new `tls.sym` file.
`nc` and libtls regression tests are changed to link only with libtls.