### PR TITLE
Fix Android CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ matrix:
       dist: bionic
       sudo: required
     - language: android
-      name: "Android 4.x"
-      env: ARCH=android MIN_NAL=14 MAX_NAL=20
+      name: "Android 8.x 9"
+      env: ARCH=android MIN_NAL=26 MAX_NAL=28
       dist: trusty
       sudo: required
       android:
@@ -49,41 +49,8 @@ matrix:
           - extra-google-m2repository
           - extra-android-m2repository
     - language: android
-      name: "Android 5.x"
-      env: ARCH=android MIN_NAL=21 MAX_NAL=22
-      dist: trusty
-      sudo: required
-      android:
-        components:
-          - tools
-          - platform-tools
-          - extra-google-m2repository
-          - extra-android-m2repository
-    - language: android
-      name: "Android 6.x 7.x"
-      env: ARCH=android MIN_NAL=23 MAX_NAL=25
-      dist: trusty
-      sudo: required
-      android:
-        components:
-          - tools
-          - platform-tools
-          - extra-google-m2repository
-          - extra-android-m2repository
-    - language: android
-      name: "Android 8.x"
-      env: ARCH=android MIN_NAL=26 MAX_NAL=27
-      dist: trusty
-      sudo: required
-      android:
-        components:
-          - tools
-          - platform-tools
-          - extra-google-m2repository
-          - extra-android-m2repository
-    - language: android
-      name: "Android 9.x 10.x"
-      env: ARCH=android MIN_NAL=28 MAX_NAL=29
+      name: "Android 10 11"
+      env: ARCH=android MIN_NAL=29 MAX_NAL=30
       dist: trusty
       sudo: required
       android:

--- a/scripts/travis
+++ b/scripts/travis
@@ -98,38 +98,37 @@ elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then
 
 elif [ "x$ARCH" = "xandroid" ]; then
 	touch $HOME/.android/repositories.cfg
-	echo y | sdkmanager 'ndk-bundle'
-	echo y | sdkmanager 'ndk;20.1.5948944'
-	echo y | sdkmanager 'cmake;3.6.4111459'
+	echo "##### Date: `date` install NDK and build tools"
+	echo y | sdkmanager 'platforms;android-30' > /dev/null 2>&1
+	echo "##### Date: `date` platforms;android installed"
+	echo y | sdkmanager 'ndk-bundle' > /dev/null 2>&1
+	echo "##### Date: `date` ndk-bundle installed"
+	echo y | sdkmanager 'ndk;22.1.7171670'
+	echo "##### Date: `date` ndk installed"
+	echo y | sdkmanager 'cmake;3.18.1'
+	echo "##### Date: `date` cmake installed"
 
-	export CMAKE=$ANDROID_HOME/cmake/3.6.4111459/bin/cmake
-	export NINJA=$ANDROID_HOME/cmake/3.6.4111459/bin/ninja
+	echo "##### Date: `date` sdkmanager --list"
+	sdkmanager --list
+
+	export CMAKE=$ANDROID_HOME/cmake/3.18.1/bin/cmake
+	export NINJA=$ANDROID_HOME/cmake/3.18.1/bin/ninja
 	export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
 	export TC_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake
 
-	# get available API level and architecture
-	pdir=$ANDROID_NDK_HOME/platforms
+	# set target API level and architecture
 	level_arch=""
 	level=$MIN_NAL
 	while [ $level -le $MAX_NAL ]
 	do
-		if [ -d $pdir/android-$level ] ; then
-			adir=$pdir/android-$level
-			if [ -d $adir/arch-arm ] ; then
-				level_arch="$level_arch $level;armeabi-v7a"
-			fi
-			if [ -d $adir/arch-arm64 ] ; then
-				level_arch="$level_arch $level;arm64-v8a"
-			fi
-			if [ -d $adir/arch-x86 ] ; then
-				level_arch="$level_arch $level;x86"
-			fi
-			if [ -d $adir/arch-x86_64 ] ; then
-				level_arch="$level_arch $level;x86_64"
-			fi
-		fi
+		level_arch="$level_arch $level;x86_64"
+		level_arch="$level_arch $level;x86"
+		level_arch="$level_arch $level;arm64-v8a"
+
 		level=`expr $level + 1`
 	done
+
+	echo "##### level_arch = $level_arch"
 
 	# build each API level and architecture
 	for la in $level_arch


### PR DESCRIPTION
Android CI build had been failing because of some SDK and NDK changes.
This PR re-enable it again.
This time, restrict the target version to 8.0 (API level 26) and above
since older version appears to finish support already.
Build x86_64, x86, armv8, and removed armv7 build.

I thought to update platform to bionic, but Travis-CI Android builds seems
to be supported on trusty only at this time still.
https://docs.travis-ci.com/user/languages/android/

- Targeted to Android 8.0 (API level 26) and above
- Build for x86_64, x86 and arm64-v8a, stop searching dir for detecting ABI
- Use newer version of ndk and cmake
- Suppress sdkmanager messages to reduce log output
- Add log messages to tell CI running right