### PR TITLE
Fix .gitignore and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ tests/gost2814789t*
 tests/key_schedule*
 tests/mont*
 tests/rfc5280time*
+tests/ssl_get_shared_ciphers*
 tests/ssl_methods*
 tests/ssl_versions*
 tests/timingsafe*

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ Makefile.in
 *.3
 *.5
 
+cert.pem
+openssl.cnf
+x509v3.cnf
+
 # tests
 test-driver
 *.log
@@ -60,6 +64,7 @@ tests/bn_rand_interval*
 tests/bn_to_string*
 tests/cipher*
 tests/constraints*
+tests/ec_point_conversion*
 tests/explicit_bzero*
 tests/freenull*
 tests/gost2814789t*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -491,6 +491,11 @@ if(NOT BUILD_SHARED_LIBS)
 	add_test(tlsexttest tlsexttest)
 endif()
 
+# tlslegacytest
+add_executable(tlslegacytest tlslegacytest.c)
+target_link_libraries(tlslegacytest ${OPENSSL_LIBS})
+add_test(tlslegacytest tlslegacytest)
+
 # tlstest
 set(TLSTEST_SRC tlstest.c)
 check_function_exists(pipe2 HAVE_PIPE2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,10 +132,9 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 # clienttest
-# disabled
-#add_executable(clienttest clienttest.c)
-#target_link_libraries(clienttest ${OPENSSL_LIBS})
-#add_test(clienttest clienttest)
+add_executable(clienttest clienttest.c)
+target_link_libraries(clienttest ${OPENSSL_LIBS})
+add_test(clienttest clienttest)
 
 # cmstest
 add_executable(cmstest cmstest.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -438,6 +438,13 @@ add_executable(sm4test sm4test.c)
 target_link_libraries(sm4test ${OPENSSL_LIBS})
 add_test(sm4test sm4test)
 
+# ssl_get_shared_ciphers
+add_executable(ssl_get_shared_ciphers ssl_get_shared_ciphers.c)
+set_source_files_properties(ssl_get_shared_ciphers.c PROPERTIES COMPILE_FLAGS
+	-DCERTSDIR=\\"${CMAKE_CURRENT_SOURCE_DIR}\\")
+target_link_libraries(ssl_get_shared_ciphers ${OPENSSL_LIBS})
+add_test(ssl_get_shared_ciphers ssl_get_shared_ciphers)
+
 # ssl_versions
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(ssl_versions ssl_versions.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -132,10 +132,9 @@ check_PROGRAMS += cipherstest
 cipherstest_SOURCES = cipherstest.c
 
 # clienttest
-# disabled
-#TESTS += clienttest
-#check_PROGRAMS += clienttest
-#clienttest_SOURCES = clienttest.c
+TESTS += clienttest
+check_PROGRAMS += clienttest
+clienttest_SOURCES = clienttest.c
 
 # cmstest
 TESTS += cmstest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -449,6 +449,11 @@ TESTS += tlsexttest
 check_PROGRAMS += tlsexttest
 tlsexttest_SOURCES = tlsexttest.c
 
+# tlslegacytest
+TESTS += tlslegacytest
+check_PROGRAMS += tlslegacytest
+tlslegacytest_SOURCES = tlslegacytest.c
+
 # tlstest
 TESTS += tlstest.sh
 check_PROGRAMS += tlstest

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -409,6 +409,12 @@ TESTS += sm4test
 check_PROGRAMS += sm4test
 sm4test_SOURCES = sm4test.c
 
+# ssl_get_shared_ciphers
+TESTS += ssl_get_shared_ciphers
+ssl_get_shared_ciphers_CPPFLAGS = $(AM_CPPFLAGS) -DCERTSDIR=\"$(srcdir)\"
+check_PROGRAMS += ssl_get_shared_ciphers
+ssl_get_shared_ciphers_SOURCES = ssl_get_shared_ciphers.c
+
 # ssl_methods
 TESTS += ssl_methods
 check_PROGRAMS += ssl_methods


### PR DESCRIPTION
- fix .gitignore for cert.pem, .cnf files and tests/ec_point_conversion
- re-enable clienttest
- add tlslegacytest
- add ssl_get_shared_ciphers
