### PR TITLE
Add dtlstest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,6 @@ matrix:
 
 script:
   "./scripts/travis"
+
+after_failure:
+  "./scripts/travis_failure"

--- a/scripts/travis_failure
+++ b/scripts/travis_failure
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+CWD=`pwd`
+
+testsdir=`ls -d libressl-*/_build/sub/tests`
+if [ -d "$testsdir" ] ; then
+	echo "##### test logs in $testsdir"
+	cd $testsdir
+	for i in `ls *.trs` ; do
+		grep ':test-result: PASS' $i > /dev/null
+		if [ $? -eq 1 ] ; then
+			log=`echo $i | sed 's/\.trs$/\.log/'`
+			echo "***** $log"
+			cat $log
+		fi
+	done
+	cd $CWD
+fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,14 @@ add_executable(dsatest dsatest.c)
 target_link_libraries(dsatest ${OPENSSL_LIBS})
 add_test(dsatest dsatest)
 
+# dtlstest
+if(NOT WIN32)
+	add_executable(dtlstest dtlstest.c)
+	target_link_libraries(dtlstest ${OPENSSL_LIBS})
+	add_test(NAME dtlstest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/dtlstest.sh)
+	set_tests_properties(dtlstest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
+endif()
+
 if(NOT BUILD_SHARED_LIBS)
 # ec_point_conversion
 add_executable(ec_point_conversion ec_point_conversion.c)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -172,6 +172,12 @@ TESTS += dsatest
 check_PROGRAMS += dsatest
 dsatest_SOURCES = dsatest.c
 
+# dtlstest
+TESTS += dtlstest.sh
+check_PROGRAMS += dtlstest
+dtlstest_SOURCES = dtlstest.c
+EXTRA_DIST += dtlstest.sh
+
 # ec_point_conversion
 TESTS += ec_point_conversion
 check_PROGRAMS += ec_point_conversion

--- a/tests/dtlstest.sh
+++ b/tests/dtlstest.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+dtlstest_bin=./dtlstest
+if [ -e ./dtlstest.exe ]; then
+	dtlstest_bin=./dtlstest.exe
+fi
+
+if [ -z $srcdir ]; then
+	srcdir=.
+fi
+
+$dtlstest_bin $srcdir/server.pem $srcdir/server.pem $srcdir/ca.pem


### PR DESCRIPTION
This PR adds regression dtlstest.
And I added after_failure script to dump failed test log by second commit,
since I sometimes saw dtlstest failed.
I would like to see if dtlstest runs successfully by this PR.