### PR TITLE
Fix mingw build on ubuntu 20.04

### DIFF
--- a/m4/check-hardening-options.m4
+++ b/m4/check-hardening-options.m4
@@ -73,7 +73,9 @@ AC_DEFUN([CHECK_C_HARDENING_OPTIONS], [
 		CHECK_CFLAG([[-fno-strict-overflow]])
 
 		# _FORTIFY_SOURCE replaces builtin functions with safer versions.
-		AX_ADD_FORTIFY_SOURCE
+		AS_IF([test "x$HOST_OS" != "xwin"], [
+			AX_ADD_FORTIFY_SOURCE
+		])
 
 		# Enable read only relocations
 		CHECK_LDFLAG([[-Wl,-z,relro]])

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -112,7 +112,7 @@ char buf[1]; getentropy(buf, 1);
 		CPPFLAGS="$CPPFLAGS -D_REENTRANT -D_POSIX_THREAD_SAFE_FUNCTIONS"
 		CPPFLAGS="$CPPFLAGS -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600"
 		CPPFLAGS="$CPPFLAGS"
-		AC_SUBST([PLATFORM_LDADD], ['-lws2_32 -lbcrypt -lssp'])
+		AC_SUBST([PLATFORM_LDADD], ['-lws2_32 -lbcrypt'])
 		;;
 	*solaris*)
 		HOST_OS=solaris

--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -112,7 +112,7 @@ char buf[1]; getentropy(buf, 1);
 		CPPFLAGS="$CPPFLAGS -D_REENTRANT -D_POSIX_THREAD_SAFE_FUNCTIONS"
 		CPPFLAGS="$CPPFLAGS -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600"
 		CPPFLAGS="$CPPFLAGS"
-		AC_SUBST([PLATFORM_LDADD], ['-lws2_32 -lbcrypt'])
+		AC_SUBST([PLATFORM_LDADD], ['-lws2_32 -lbcrypt -lssp'])
 		;;
 	*solaris*)
 		HOST_OS=solaris

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -172,9 +172,11 @@ check_PROGRAMS += dsatest
 dsatest_SOURCES = dsatest.c
 
 # dtlstest
+if !HOST_WIN
 TESTS += dtlstest.sh
 check_PROGRAMS += dtlstest
 dtlstest_SOURCES = dtlstest.c
+endif
 EXTRA_DIST += dtlstest.sh
 
 # ec_point_conversion


### PR DESCRIPTION
I believe this PR would solve #649 and MinGW build failure on ubuntu 20.04 in #672 .
I saw "undefined reference to `__memcpy_chk'" error while building on ubuntu 20.04.
ubuntu 20.04 appears to install MinGW 7.0.0, and it requires to link libssp if we define "-D_FORTIFY_SOURCE=2".
I also disabled dtlstest with MinGW since it does not have poll.
