### PR TITLE
Support operating systems without some non-POSIX headers

### DIFF
--- a/include/compat/arpa/nameser.h
+++ b/include/compat/arpa/nameser.h
@@ -4,7 +4,9 @@
  */
 
 #ifndef _WIN32
+#ifdef HAVE_ARPA_NAMESER_H
 #include_next <arpa/nameser.h>
+#endif
 #else
 #include <win32netcompat.h>
 

--- a/include/compat/machine/endian.h
+++ b/include/compat/machine/endian.h
@@ -21,7 +21,7 @@
 #define BYTE_ORDER BIG_ENDIAN
 #endif
 
-#elif defined(__linux__) || defined(__midipix__)
+#elif defined(HAVE_ENDIAN_H)
 #include <endian.h>
 
 #elif defined(__sun) || defined(_AIX) || defined(__hpux)

--- a/include/compat/netinet/ip.h
+++ b/include/compat/netinet/ip.h
@@ -8,7 +8,9 @@
 #endif
 
 #ifndef _WIN32
+#ifdef HAVE_NETINET_IP_H
 #include_next <netinet/ip.h>
+#endif
 #else
 #include <win32netcompat.h>
 #endif

--- a/include/compat/resolv.h
+++ b/include/compat/resolv.h
@@ -12,7 +12,7 @@
 #else
 #include <../include/resolv.h>
 #endif
-#else
+#elif defined(HAVE_RESOLV_H)
 #include_next <resolv.h>
 #endif
 

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -1,6 +1,7 @@
 AC_DEFUN([CHECK_LIBC_COMPAT], [
 # Check for libc headers
 AC_CHECK_HEADERS([err.h readpassphrase.h])
+AC_CHECK_HEADERS([arpa/nameser.h endian.h netinet/ip.h resolv.h])
 # Check for general libc functions
 AC_CHECK_FUNCS([asprintf freezero memmem])
 AC_CHECK_FUNCS([readpassphrase reallocarray recallocarray])
@@ -9,10 +10,7 @@ AC_CHECK_FUNCS([timegm _mkgmtime timespecsub])
 AC_CHECK_FUNCS([getprogname syslog syslog_r])
 AC_CACHE_CHECK([for getpagesize], ac_cv_func_getpagesize, [
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-// Since Android NDK v16 getpagesize is defined as inline inside unistd.h
-#ifdef __ANDROID__
-#	include <unistd.h>
-#endif
+#include <unistd.h>
 		]], [[
 	getpagesize();
 ]])],


### PR DESCRIPTION
I've successfully been shipping LibreSSL on Sortix for years now, a new system that doesn't yet have so many extensions beyond core POSIX, and these are my local patches that applies to libressl-portable suitable for upstreaming. This change helps LibreSSL handle systems without some non-essential and non-POSIX headers.

The `arpa/nameser.h`, `netinet/ip.h`, and `resolv.h` headers are not crucial to building LibreSSL. This change avoids including them if they're not around. The `netinet/ip.h` header is used in `nc(1)` for optional `IPTOS_` features that can be ifdef'd on systems without support (but that source file is not part of libressl-portable).

The `endian.h` header is the upcoming standard header and should be used whenever available and correct. The `machine/endian.h` header is non-standard and doesn't have to exist on POSIX systems. This change prefers `endian.h` over `machine/endian.h`, although I worry some systems might have a defective `endian.h` that doesn't work without the appropriate feature macros and such. If that is the case, logic could be added to prefer `machine/endian.h`.

The check for `getpagesize(3)` didn't forward declare the function, meaning the check fails if `CFLAGS` contains ` -Werror=implicit-function-declaration doesn't`. (Sortix getpagesize(3) currently returns `size_t`, not `int`, which causes a conflict with the forward declaration because `HAVE_GETPAGESIZE`. However, I recall `HAVE_GETPAGESIZE` still wasn't defined even when I fixed the check, so you might want to review all the related logic and see if there's anything wrong with it.)