### PR TITLE
Add the option to support an Apple-style xcframework for tls, ssl, an…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,19 @@ if(LIBRESSL_APPS AND LIBRESSL_TESTS)
 	add_subdirectory(tests)
 endif()
 
+if (BUILD_APPLE_XCFRAMEWORK)
+	# Create the super library from object libraries
+	add_library(LibreSSL_xcframework
+			$<TARGET_OBJECTS:crypto_obj> $<TARGET_OBJECTS:tls_obj> $<TARGET_OBJECTS:ssl_obj>)
+	set_target_properties(LibreSSL_xcframework PROPERTIES
+			OUTPUT_NAME ressl)
+
+	if(ENABLE_LIBRESSL_INSTALL)
+		install(TARGETS LibreSSL_xcframework
+				LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+	endif(ENABLE_LIBRESSL_INSTALL)
+endif(BUILD_APPLE_XCFRAMEWORK)
+
 if(NOT MSVC)
 	# Create pkgconfig files.
 	set(prefix      ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
The best way to support building an existing library for Apple's multiple SDKs and providing a 'cross-Apple' library is to build a single object library for each SDK (macosx, iphoneos, iphonesimulator) and then join them together using xcodebuild -create-xcframework -library ... -headers ... -output. This change will build the super library called libressl.a 