### PR TITLE
Specify local include paths for each regressions individually

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,7 @@
 include_directories(
 	.
-	../crypto/modes
-	../crypto/asn1
-	../crypto/x509
-	../ssl
-	../tls
-	../apps/openssl
-	../apps/openssl/compat
 	../include/compat
 )
-
-add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/cert.pem\")
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCE_DIR)
 
@@ -39,6 +30,8 @@ add_test(asn1evp asn1evp)
 
 # asn1test
 add_executable(asn1test asn1test.c)
+set_source_files_properties(asn1test.c PROPERTIES
+	INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 target_link_libraries(asn1test ${OPENSSL_LIBS})
 add_test(asn1test asn1test)
 
@@ -96,6 +89,8 @@ endif()
 # buffertest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(buffertest buffertest.c)
+	set_source_files_properties(buffertest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(buffertest ${OPENSSL_LIBS})
 	add_test(buffertest buffertest)
 endif()
@@ -103,6 +98,8 @@ endif()
 # bytestringtest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(bytestringtest bytestringtest.c)
+	set_source_files_properties(bytestringtest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(bytestringtest ${OPENSSL_LIBS})
 	add_test(bytestringtest bytestringtest)
 endif()
@@ -120,6 +117,8 @@ add_test(chachatest chachatest)
 # cipher_list
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(cipher_list cipher_list.c)
+	set_source_files_properties(cipher_list.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(cipher_list ${OPENSSL_LIBS})
 	add_test(cipher_list cipher_list)
 endif()
@@ -149,6 +148,8 @@ add_test(configtest configtest)
 # constraints
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(constraints constraints.c)
+	set_source_files_properties(constraints.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/x509)
 	target_link_libraries(constraints ${OPENSSL_LIBS})
 	add_test(constraints constraints)
 endif()
@@ -176,6 +177,8 @@ add_test(dsatest dsatest)
 # dtlstest
 if(NOT BUILD_SHARED_LIBS AND NOT WIN32)
 	add_executable(dtlstest dtlstest.c)
+	set_source_files_properties(dtlstest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(dtlstest ${OPENSSL_LIBS})
 	add_test(NAME dtlstest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/dtlstest.sh)
 	set_tests_properties(dtlstest PROPERTIES ENVIRONMENT "srcdir=${TEST_SOURCE_DIR}")
@@ -252,6 +255,8 @@ add_test(gost2814789t gost2814789t)
 # handshake_table
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(handshake_table handshake_table.c)
+	set_source_files_properties(handshake_table.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(handshake_table ${OPENSSL_LIBS})
 	add_test(handshake_table handshake_table)
 endif()
@@ -279,10 +284,14 @@ add_test(igetest igetest)
 # keypairtest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(key_schedule key_schedule.c)
+	set_source_files_properties(key_schedule.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(key_schedule ${OPENSSL_LIBS})
 	add_test(key_schedule key_schedule)
 
 	add_executable(keypairtest keypairtest.c)
+	set_source_files_properties(keypairtest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../tls)
 	target_link_libraries(keypairtest ${LIBTLS_LIBS})
 	add_test(keypairtest keypairtest
 		${CMAKE_CURRENT_SOURCE_DIR}/ca.pem
@@ -308,6 +317,8 @@ add_test(mont mont)
 # ocsp_test
 if(ENABLE_EXTRATESTS)
 	add_executable(ocsp_test ocsp_test.c)
+	set_source_files_properties(ocsp_test.c PROPERTIES COMPILE_FLAGS
+		-D_PATH_SSL_CA_FILE=\\"${CMAKE_CURRENT_SOURCE_DIR}/../cert.pem\\")
 	target_link_libraries(ocsp_test ${OPENSSL_LIBS})
 	if(NOT MSVC)
 		add_test(NAME ocsptest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ocsptest.sh)
@@ -318,6 +329,9 @@ endif()
 
 # optionstest
 add_executable(optionstest optionstest.c)
+set_source_files_properties(optionstest.c PROPERTIES
+	INCLUDE_DIRECTORIES
+	"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl;${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/compat")
 target_link_libraries(optionstest ${OPENSSL_LIBS})
 add_test(optionstest optionstest)
 
@@ -379,6 +393,8 @@ add_test(rc4test rc4test)
 # recordtest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(recordtest recordtest.c)
+	set_source_files_properties(recordtest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(recordtest ${OPENSSL_LIBS})
 	add_test(recordtest recordtest)
 endif()
@@ -386,6 +402,8 @@ endif()
 # record_layer_test
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(record_layer_test record_layer_test.c)
+	set_source_files_properties(record_layer_test.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(record_layer_test ${OPENSSL_LIBS})
 	add_test(record_layer_test record_layer_test)
 endif()
@@ -448,20 +466,25 @@ add_test(sm4test sm4test)
 
 # ssl_get_shared_ciphers
 add_executable(ssl_get_shared_ciphers ssl_get_shared_ciphers.c)
-set_source_files_properties(ssl_get_shared_ciphers.c PROPERTIES COMPILE_FLAGS
-	-DCERTSDIR=\\"${CMAKE_CURRENT_SOURCE_DIR}\\")
+set_source_files_properties(ssl_get_shared_ciphers.c PROPERTIES
+	COMPILE_FLAGS -DCERTSDIR=\\"${CMAKE_CURRENT_SOURCE_DIR}\\"
+	INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 target_link_libraries(ssl_get_shared_ciphers ${OPENSSL_LIBS})
 add_test(ssl_get_shared_ciphers ssl_get_shared_ciphers)
 
 # ssl_versions
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(ssl_versions ssl_versions.c)
+	set_source_files_properties(ssl_versions.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(ssl_versions ${OPENSSL_LIBS})
 	add_test(ssl_versions ssl_versions)
 endif()
 
 # ssltest
 add_executable(ssltest ssltest.c)
+set_source_files_properties(ssltest.c PROPERTIES
+	INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 target_link_libraries(ssltest ${OPENSSL_LIBS})
 if(NOT MSVC)
 	add_test(NAME ssltest COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/ssltest.sh)
@@ -502,6 +525,8 @@ add_test(timingsafe timingsafe)
 # tlsexttest
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(tlsexttest tlsexttest.c)
+	set_source_files_properties(tlsexttest.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(tlsexttest ${OPENSSL_LIBS})
 	add_test(tlsexttest tlsexttest)
 endif()
@@ -534,6 +559,8 @@ endif()
 # tls_ext_alpn
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(tls_ext_alpn tls_ext_alpn.c)
+	set_source_files_properties(tls_ext_alpn.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(tls_ext_alpn ${OPENSSL_LIBS})
 	add_test(tls_ext_alpn tls_ext_alpn)
 endif()
@@ -541,6 +568,8 @@ endif()
 # tls_prf
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(tls_prf tls_prf.c)
+	set_source_files_properties(tls_prf.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(tls_prf ${OPENSSL_LIBS})
 	add_test(tls_prf tls_prf)
 endif()
@@ -548,6 +577,8 @@ endif()
 # utf8test
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(utf8test utf8test.c)
+	set_source_files_properties(utf8test.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../crypto/asn1)
 	target_link_libraries(utf8test ${OPENSSL_LIBS})
 	add_test(utf8test utf8test)
 endif()
@@ -555,6 +586,8 @@ endif()
 # valid_handshakes_terminate
 if(NOT BUILD_SHARED_LIBS)
 	add_executable(valid_handshakes_terminate valid_handshakes_terminate.c)
+	set_source_files_properties(valid_handshakes_terminate.c PROPERTIES
+		INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/../ssl)
 	target_link_libraries(valid_handshakes_terminate ${OPENSSL_LIBS})
 	add_test(valid_handshakes_terminate valid_handshakes_terminate)
 endif()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,14 +1,5 @@
 include $(top_srcdir)/Makefile.am.common
 
-AM_CPPFLAGS += -I $(top_srcdir)/crypto/modes
-AM_CPPFLAGS += -I $(top_srcdir)/crypto/asn1
-AM_CPPFLAGS += -I $(top_srcdir)/crypto/x509
-AM_CPPFLAGS += -I $(top_srcdir)/ssl
-AM_CPPFLAGS += -I $(top_srcdir)/tls
-AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
-AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
-AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/apps/openssl/cert.pem\"
-
 LDADD = $(abs_top_builddir)/tls/.libs/libtls.a
 LDADD += $(abs_top_builddir)/ssl/.libs/libssl.a
 LDADD += $(abs_top_builddir)/crypto/.libs/libcrypto.a
@@ -52,6 +43,7 @@ asn1evp_SOURCES = asn1evp.c
 
 # asn1test
 TESTS += asn1test
+asn1test_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += asn1test
 asn1test_SOURCES = asn1test.c
 
@@ -101,12 +93,13 @@ bn_to_string_SOURCES = bn_to_string.c
 
 # buffertest
 TESTS += buffertest
-buffertest_CPPFLAGS = $(AM_CPPFLAGS)
+buffertest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += buffertest
 buffertest_SOURCES = buffertest.c
 
 # bytestringtest
 TESTS += bytestringtest
+bytestringtest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += bytestringtest
 bytestringtest_SOURCES = bytestringtest.c
 
@@ -122,6 +115,7 @@ chachatest_SOURCES = chachatest.c
 
 # cipher_list
 TESTS += cipher_list
+cipher_list_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += cipher_list
 cipher_list_SOURCES = cipher_list.c
 noinst_HEADERS = tests.h
@@ -148,6 +142,7 @@ configtest_SOURCES = configtest.c
 
 # constraints
 TESTS += constraints
+constraints_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/crypto/x509
 check_PROGRAMS += constraints
 constraints_SOURCES = constraints.c
 
@@ -174,6 +169,7 @@ dsatest_SOURCES = dsatest.c
 # dtlstest
 if !HOST_WIN
 TESTS += dtlstest.sh
+dtlstest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += dtlstest
 dtlstest_SOURCES = dtlstest.c
 endif
@@ -247,6 +243,7 @@ gost2814789t_SOURCES = gost2814789t.c
 
 # handshake_table
 TESTS += handshake_table
+handshake_table_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += handshake_table
 handshake_table_SOURCES = handshake_table.c
 
@@ -272,12 +269,14 @@ igetest_SOURCES = igetest.c
 
 # keypairtest
 TESTS += keypairtest.sh
+keypairtest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/tls
 check_PROGRAMS += keypairtest
 keypairtest_SOURCES = keypairtest.c
 EXTRA_DIST += keypairtest.sh
 
 # key_schedule
 TESTS += key_schedule
+key_schedule_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += key_schedule
 key_schedule_SOURCES = key_schedule.c
 
@@ -299,6 +298,7 @@ mont_SOURCES = mont.c
 # ocsp_test
 if ENABLE_EXTRATESTS
 TESTS += ocsptest.sh
+ocsp_test_CPPFLAGS = $(AM_CPPFLAGS) -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/cert.pem\"
 check_PROGRAMS += ocsp_test
 ocsp_test_SOURCES = ocsp_test.c
 endif
@@ -306,6 +306,7 @@ EXTRA_DIST += ocsptest.sh ocsptest.bat
 
 # optionstest
 TESTS += optionstest
+optionstest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/apps/openssl -I $(top_srcdir)/apps/openssl/compat
 check_PROGRAMS += optionstest
 optionstest_SOURCES = optionstest.c
 
@@ -358,11 +359,13 @@ rc4test_SOURCES = rc4test.c
 
 # recordtest
 TESTS += recordtest
+recordtest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += recordtest
 recordtest_SOURCES = recordtest.c
 
 # record_layer_test
 TESTS += record_layer_test
+record_layer_test_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += record_layer_test
 record_layer_test_SOURCES = record_layer_test.c
 
@@ -430,11 +433,13 @@ ssl_methods_SOURCES = ssl_methods.c
 
 # ssl_versions
 TESTS += ssl_versions
+ssl_versions_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += ssl_versions
 ssl_versions_SOURCES = ssl_versions.c
 
 # ssltest
 TESTS += ssltest.sh
+ssltest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += ssltest
 ssltest_SOURCES = ssltest.c
 EXTRA_DIST += ssltest.sh ssltest.bat
@@ -460,6 +465,7 @@ timingsafe_SOURCES = timingsafe.c
 
 # tlsexttest
 TESTS += tlsexttest
+tlsexttest_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += tlsexttest
 tlsexttest_SOURCES = tlsexttest.c
 
@@ -479,21 +485,25 @@ EXTRA_DIST += tlstest.sh tlstest.bat
 
 # tls_ext_alpn
 TESTS += tls_ext_alpn
+tls_ext_alpn_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += tls_ext_alpn
 tls_ext_alpn_SOURCES = tls_ext_alpn.c
 
 # tls_prf
 TESTS += tls_prf
+tls_prf_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += tls_prf
 tls_prf_SOURCES = tls_prf.c
 
 # utf8test
 TESTS += utf8test
+utf8test_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/crypto/asn1
 check_PROGRAMS += utf8test
 utf8test_SOURCES = utf8test.c
 
 # valid_handshakes_terminate
 TESTS += valid_handshakes_terminate
+valid_handshakes_terminate_CPPFLAGS = $(AM_CPPFLAGS) -I $(top_srcdir)/ssl
 check_PROGRAMS += valid_handshakes_terminate
 valid_handshakes_terminate_SOURCES = valid_handshakes_terminate.c
 


### PR DESCRIPTION
For regressions, specify local include path for each source files instead of adding them to AM_CPPFLAGS or include_directories.
Now upstream has the same name local header files in ssl/ and tls/, and this brings some regressions build break.
This PR avoid that issue.

Also change the path of cert.pem for ocsp_test.
cert.pem was moved from apps/openssl/ to top directory.