### PR TITLE
Set IA-64 compiler flag only if it is HP-UX with IA-64

### DIFF
--- a/m4/check-os-options.m4
+++ b/m4/check-os-options.m4
@@ -68,10 +68,15 @@ char buf[1]; getentropy(buf, 1);
 		;;
 	*hpux*)
 		HOST_OS=hpux;
-		if test "`echo $CC | cut -d ' ' -f 1`" = "gcc" ; then
-			CFLAGS="$CFLAGS -mlp64"
-		else
-			CFLAGS="-g -O2 +DD64 +Otype_safety=off $USER_CFLAGS"
+		if test "`echo $host_os | cut -c 1-4`" = "ia64" ; then
+			if test "`echo $CC | cut -d ' ' -f 1`" = "gcc" ; then
+				CFLAGS="$CFLAGS -mlp64"
+			else
+				CFLAGS="+DD64"
+			fi
+		fi
+		if ! test "`echo $CC | cut -d ' ' -f 1`" = "gcc" ; then
+			CFLAGS="-g -O2 +Otype_safety=off $CFLAGS $USER_CFLAGS"
 		fi
 		CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600 -D__STRICT_ALIGNMENT"
 		;;


### PR DESCRIPTION
Compiler switch -mlp64 (GCC) or +DD64(HP CC) gives build failure with
platform HP-UX other than IA-64.
This avoids build break on HP-UX with PA-RISC platform.

Suggested from Larkin Nickle (me <at> larbob org) by libressl ML.
https://marc.info/?l=libressl&m=163649798619783&w=2