### PR TITLE
Avoid accessing ASN1 item in regress x509req_ext.c on Windows platform

### DIFF
--- a/patches/x509req_ext.c.patch
+++ b/patches/x509req_ext.c.patch
@@ -1,0 +1,18 @@
+--- tests/x509req_ext.c.orig	Tue Nov 23 18:31:32 2021
++++ tests/x509req_ext.c	Tue Nov 23 18:41:56 2021
+@@ -136,6 +136,7 @@
+ 	}
+ 	if ((irc = ASN1_TYPE_get(aval)) != V_ASN1_SEQUENCE)
+ 		fail_int("ASN1_TYPE_get", irc);
++#ifndef _MSC_VER
+ 	exts = ASN1_item_unpack(aval->value.sequence, &X509_EXTENSIONS_it);
+ 	if (exts == NULL) {
+ 		fail_str("ASN1_item_unpack", "NULL");
+@@ -144,6 +145,7 @@
+ 	if ((irc = sk_X509_EXTENSION_num(exts)) != 0)
+ 		fail_int("sk_X509_EXTENSION_num", irc);
+ 	sk_X509_EXTENSION_free(exts);
++#endif
+ 
+ end_valid:
+ 	testname = "getext";


### PR DESCRIPTION
Now regress x509req_ext fails on Windows shared build, since it can not access ASN1 item X509_EXTENSIONS_it in DLL.
I thought one solution would be a patch to disable calling ASN1_item_unpack.
It is better if we could disable it when shared build only, but I had no idea to do that.
Another solution would be off this test when Windows shared build.
Thoughts, comments or any other idea ?