### PR TITLE
Remove unneeded target_include_directories with cmake

### DIFF
--- a/apps/nc/CMakeLists.txt
+++ b/apps/nc/CMakeLists.txt
@@ -44,6 +44,7 @@ else()
 endif()
 
 add_executable(nc ${NC_SRC})
+target_include_directories(nc PUBLIC ../../include)
 target_include_directories(nc PRIVATE . ./compat ../../include/compat)
 target_link_libraries(nc ${LIBTLS_LIBS})
 

--- a/apps/ocspcheck/CMakeLists.txt
+++ b/apps/ocspcheck/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
 endif()
 
 add_executable(ocspcheck ${OCSPCHECK_SRC})
+target_include_directories(ocspcheck PUBLIC ../../include)
 target_include_directories(ocspcheck PRIVATE . ./compat ../../include/compat)
 target_link_libraries(ocspcheck tls ${OPENSSL_LIBS})
 

--- a/apps/openssl/CMakeLists.txt
+++ b/apps/openssl/CMakeLists.txt
@@ -77,6 +77,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 endif()
 
 add_executable(openssl ${OPENSSL_SRC})
+target_include_directories(openssl PUBLIC ../../include)
 target_include_directories(openssl PRIVATE . ../../include/compat)
 target_link_libraries(openssl ${OPENSSL_LIBS})
 

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1003,21 +1003,6 @@ target_include_directories(crypto_obj
 		../include)
 
 add_library(crypto $<TARGET_OBJECTS:crypto_obj>)
-target_include_directories(crypto
-	PRIVATE
-		.
-		asn1
-		bn
-		dsa
-		ec
-		ecdh
-		ecdsa
-		evp
-		modes
-		x509
-		../include/compat
-	PUBLIC
-		../include)
 
 export_symbol(crypto ${CMAKE_CURRENT_BINARY_DIR}/crypto_p.sym)
 target_link_libraries(crypto ${PLATFORM_LIBS})
@@ -1042,21 +1027,6 @@ endif(ENABLE_LIBRESSL_INSTALL)
 # build static library for regression test
 if(BUILD_SHARED_LIBS)
 	add_library(crypto-static STATIC $<TARGET_OBJECTS:crypto_obj>)
-	target_include_directories(crypto-static
-		PRIVATE
-			.
-			asn1
-			bn
-			dsa
-			ec
-			ecdh
-			ecdsa
-			evp
-			modes
-			x509
-			../include/compat
-		PUBLIC
-			../include)
 	target_link_libraries(crypto-static ${PLATFORM_LIBS})
 endif()
 

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -63,12 +63,6 @@ target_include_directories(ssl_obj
 		../include)
 
 add_library(ssl $<TARGET_OBJECTS:ssl_obj>)
-target_include_directories(ssl
-	PRIVATE
-		.
-		../include/compat
-	PUBLIC
-		../include)
 
 export_symbol(ssl ${CMAKE_CURRENT_SOURCE_DIR}/ssl.sym)
 target_link_libraries(ssl crypto ${PLATFORM_LIBS})
@@ -93,12 +87,6 @@ endif(ENABLE_LIBRESSL_INSTALL)
 # build static library for regression test
 if(BUILD_SHARED_LIBS)
 	add_library(ssl-static STATIC $<TARGET_OBJECTS:ssl_obj>)
-	target_include_directories(ssl-static
-		PRIVATE
-			.
-			../include/compat
-		PUBLIC
-			../include)
 	target_link_libraries(ssl-static crypto-static ${PLATFORM_LIBS})
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
 	../ssl
 	../apps/openssl
 	../apps/openssl/compat
+	../include
 	../include/compat
 )
 

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -48,12 +48,6 @@ target_include_directories(tls_obj
 
 add_library(tls $<TARGET_OBJECTS:tls_obj> $<TARGET_OBJECTS:ssl_obj>
 	$<TARGET_OBJECTS:crypto_obj>)
-target_include_directories(tls
-	PRIVATE
-		.
-		../include/compat
-	PUBLIC
-		../include)
 
 export_symbol(tls ${CMAKE_CURRENT_BINARY_DIR}/tls.sym)
 target_link_libraries(tls ${PLATFORM_LIBS})
@@ -79,12 +73,6 @@ endif(ENABLE_LIBRESSL_INSTALL)
 if(BUILD_SHARED_LIBS)
 	add_library(tls-static STATIC $<TARGET_OBJECTS:tls_obj>
 		$<TARGET_OBJECTS:ssl_obj> $<TARGET_OBJECTS:crypto_obj>)
-	target_include_directories(tls-static
-		PRIVATE
-			.
-			../include/compat
-		PUBLIC
-			../include)
 	target_link_libraries(tls-static ${PLATFORM_LIBS})
 endif()
 


### PR DESCRIPTION
This could remove recurring of the same statement for include directories.
Instead of this removals, apps/* and tests  should have include path that
had been provided by INTERFACE_INCLUDE_DIRECTORIES of target libs and
internal static libs.