### PR TITLE
assort tests cleanup

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(
 	../include/compat
 )
 
-add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../apps/openssl/cert.pem\")
+add_definitions(-D_PATH_SSL_CA_FILE=\"${CMAKE_CURRENT_SOURCE_DIR}/../cert.pem\")
 
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCE_DIR)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -424,6 +424,11 @@ set_source_files_properties(ssl_get_shared_ciphers.c PROPERTIES COMPILE_FLAGS
 target_link_libraries(ssl_get_shared_ciphers ${OPENSSL_TEST_LIBS})
 add_test(ssl_get_shared_ciphers ssl_get_shared_ciphers)
 
+# ssl_methods
+add_executable(ssl_methods ssl_methods.c)
+target_link_libraries(ssl_methods ${OPENSSL_TEST_LIBS})
+add_test(ssl_methods ssl_methods)
+
 # ssl_versions
 add_executable(ssl_versions ssl_versions.c)
 target_link_libraries(ssl_versions ${OPENSSL_TEST_LIBS})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -273,17 +273,17 @@ TESTS += igetest
 check_PROGRAMS += igetest
 igetest_SOURCES = igetest.c
 
+# key_schedule
+TESTS += key_schedule
+check_PROGRAMS += key_schedule
+key_schedule_SOURCES = key_schedule.c
+
 # keypairtest
 TESTS += keypairtest.sh
 keypairtest_CPPFLAGS = -I $(top_srcdir)/tls $(AM_CPPFLAGS)
 check_PROGRAMS += keypairtest
 keypairtest_SOURCES = keypairtest.c
 EXTRA_DIST += keypairtest.sh
-
-# key_schedule
-TESTS += key_schedule
-check_PROGRAMS += key_schedule
-key_schedule_SOURCES = key_schedule.c
 
 # md4test
 TESTS += md4test

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS += -I $(top_srcdir)/crypto/x509
 AM_CPPFLAGS += -I $(top_srcdir)/ssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
-AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/apps/openssl/cert.pem\"
+AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/cert.pem\"
 
 LDADD = $(abs_top_builddir)/tls/.libs/libtls.a
 LDADD += $(abs_top_builddir)/ssl/.libs/libssl.a


### PR DESCRIPTION
- Add regress ssl_methods to cmake
- Sort regress key_schedule in Makefile.am
- Fix _PATH_SSL_CA_FILE for ocsp_test
