### PR TITLE
Add strtonum to compat library and export it

### DIFF
--- a/apps/nc/CMakeLists.txt
+++ b/apps/nc/CMakeLists.txt
@@ -29,14 +29,6 @@ else()
 	set(NC_SRC ${NC_SRC} compat/readpassphrase.c)
 endif()
 
-check_function_exists(strtonum HAVE_STRTONUM)
-if(HAVE_STRTONUM AND CMAKE_SYSTEM_NAME MATCHES "Darwin" AND
-    CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20)
-	add_definitions(-DHAVE_STRTONUM)
-else()
-	set(NC_SRC ${NC_SRC} compat/strtonum.c)
-endif()
-
 if(NOT "${OPENSSLDIR}" STREQUAL "")
 	add_definitions(-DDEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
 else()

--- a/apps/nc/Makefile.am
+++ b/apps/nc/Makefile.am
@@ -43,8 +43,4 @@ if !HAVE_READPASSPHRASE
 nc_SOURCES += compat/readpassphrase.c
 endif
 
-if !HAVE_STRTONUM
-nc_SOURCES += compat/strtonum.c
-endif
-
 endif

--- a/apps/ocspcheck/CMakeLists.txt
+++ b/apps/ocspcheck/CMakeLists.txt
@@ -13,14 +13,6 @@ else()
         set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/memmem.c)
 endif()
 
-check_function_exists(strtonum HAVE_STRTONUM)
-if(HAVE_STRTONUM AND CMAKE_SYSTEM_NAME MATCHES "Darwin" AND
-    CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20)
-	add_definitions(-DHAVE_STRTONUM)
-else()
-	set(OCSPCHECK_SRC ${OCSPCHECK_SRC} compat/strtonum.c)
-endif()
-
 if(NOT "${OPENSSLDIR}" STREQUAL "")
 	add_definitions(-DDEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
 else()

--- a/apps/ocspcheck/Makefile.am
+++ b/apps/ocspcheck/Makefile.am
@@ -22,7 +22,3 @@ noinst_HEADERS = http.h
 if !HAVE_MEMMEM
 ocspcheck_SOURCES += compat/memmem.c
 endif
-
-if !HAVE_STRTONUM
-ocspcheck_SOURCES += compat/strtonum.c
-endif

--- a/apps/openssl/CMakeLists.txt
+++ b/apps/openssl/CMakeLists.txt
@@ -61,14 +61,6 @@ if(WIN32)
 	set(OPENSSL_SRC ${OPENSSL_SRC} compat/poll_win.c)
 endif()
 
-check_function_exists(strtonum HAVE_STRTONUM)
-if(HAVE_STRTONUM AND CMAKE_SYSTEM_NAME MATCHES "Darwin" AND
-    CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20)
-	add_definitions(-DHAVE_STRTONUM)
-else()
-	set(OPENSSL_SRC ${OPENSSL_SRC} compat/strtonum.c)
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
         check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
         if(NOT HAVE_CLOCK_GETTIME)

--- a/apps/openssl/Makefile.am
+++ b/apps/openssl/Makefile.am
@@ -84,10 +84,6 @@ openssl_SOURCES += compat/clock_gettime_osx.c
 endif
 endif
 
-if !HAVE_STRTONUM
-openssl_SOURCES += compat/strtonum.c
-endif
-
 noinst_HEADERS = apps.h
 noinst_HEADERS += progs.h
 noinst_HEADERS += s_apps.h

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -888,6 +888,11 @@ if(NOT HAVE_STRSEP)
 	set(EXTRA_EXPORT ${EXTRA_EXPORT} strsep)
 endif()
 
+if(NOT HAVE_STRTONUM)
+	set(CRYPTO_SRC ${CRYPTO_SRC} compat/strtonum.c)
+	set(EXTRA_EXPORT ${EXTRA_EXPORT} strtonum)
+endif()
+
 if(NOT HAVE_SYSLOG_R)
 	set(CRYPTO_SRC ${CRYPTO_SRC} compat/syslog_r.c)
 endif()

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -76,6 +76,9 @@ endif
 if !HAVE_STRSEP
 	-echo strsep >> crypto_portable.sym
 endif
+if !HAVE_STRTONUM
+	-echo strtonum >> crypto_portable.sym
+endif
 if !HAVE_TIMEGM
 	-echo timegm >> crypto_portable.sym
 endif
@@ -173,6 +176,10 @@ endif
 
 if !HAVE_STRSEP
 libcompat_la_SOURCES += compat/strsep.c
+endif
+
+if !HAVE_STRTONUM
+libcompat_la_SOURCES += compat/strtonum.c
 endif
 
 if !HAVE_ASPRINTF

--- a/tests/optionstest.c
+++ b/tests/optionstest.c
@@ -24,7 +24,6 @@
 
 #include <apps.h>
 #include <apps.c>
-#include <strtonum.c>
 
 /* Needed to keep apps.c happy... */
 BIO *bio_err;

--- a/update.sh
+++ b/update.sh
@@ -82,6 +82,7 @@ for i in crypto/compat; do
 	    $libc_src/crypt/chacha_private.h \
 	    $libc_src/stdlib/reallocarray.c \
 	    $libc_src/stdlib/recallocarray.c \
+	    $libc_src/stdlib/strtonum.c \
 	    $libc_src/string/explicit_bzero.c \
 	    $libc_src/string/strcasecmp.c \
 	    $libc_src/string/strlcpy.c \
@@ -243,7 +244,6 @@ echo "copying nc(1) source"
 $CP $bin_src/nc/nc.1 apps/nc
 rm -f apps/nc/*.c apps/nc/*.h
 $CP_LIBC $libc_src/net/base64.c apps/nc/compat
-$CP_LIBC $libc_src/stdlib/strtonum.c apps/nc/compat
 for i in `awk '/SOURCES|HEADERS|MANS/ { print $3 }' apps/nc/Makefile.am` ; do
 	if [ -e $bin_src/nc/$i ]; then
 		$CP $bin_src/nc/$i apps/nc
@@ -255,7 +255,6 @@ echo "copying ocspcheck(1) source"
 $CP $sbin_src/ocspcheck/ocspcheck.8 apps/ocspcheck
 rm -f apps/ocspcheck/*.c apps/ocspcheck/*.h
 $CP_LIBC $libc_src/string/memmem.c apps/ocspcheck/compat
-$CP_LIBC $libc_src/stdlib/strtonum.c apps/ocspcheck/compat
 for i in `awk '/SOURCES|HEADERS|MANS/ { print $3 }' apps/ocspcheck/Makefile.am` ; do
 	if [ -e $sbin_src/ocspcheck/$i ]; then
 		$CP $sbin_src/ocspcheck/$i apps/ocspcheck
@@ -265,7 +264,6 @@ done
 # copy openssl(1) source
 echo "copying openssl(1) source"
 $CP $bin_src/openssl/openssl.1 apps/openssl
-$CP_LIBC $libc_src/stdlib/strtonum.c apps/openssl/compat
 $CP $libcrypto_src/cert.pem .
 $CP $libcrypto_src/openssl.cnf .
 $CP $libcrypto_src/x509v3.cnf .


### PR DESCRIPTION
crypto library requires strtonum now, and add it to compat library.
remove it from applications compat/ directories.