### PR TITLE
Fix unreachable nc portability shim

### DIFF
--- a/apps/nc/compat/sys/socket.h
+++ b/apps/nc/compat/sys/socket.h
@@ -6,8 +6,7 @@
 #ifndef _WIN32
 #include_next <sys/socket.h>
 
-#if !defined(SOCK_NONBLOCK) || !defined(SOCK_CLOEXEC)
-#define NEED_SOCKET_FLAGS
+#if defined(NEED_SOCKET_FLAGS)
 int _socket(int domain, int type, int protocol);
 #ifndef SOCKET_FLAGS_PRIV
 #define socket(d, t, p) _socket(d, t, p)

--- a/include/compat/sys/socket.h
+++ b/include/compat/sys/socket.h
@@ -10,6 +10,7 @@
 #endif
 
 #if !defined(SOCK_NONBLOCK) || !defined(SOCK_CLOEXEC)
+#define NEED_SOCKET_FLAGS
 #define SOCK_CLOEXEC            0x8000  /* set FD_CLOEXEC */
 #define SOCK_NONBLOCK           0x4000  /* set O_NONBLOCK */
 int bsd_socketpair(int domain, int type, int protocol, int socket_vector[2]);


### PR DESCRIPTION
This fixes nc failing to run on darwin due to it incorrectly setting the
linux-specific SOCK_NONBLOCK flag on connect.

nc already had a portability shim in apps/nc/compat/sys/socket.h, which
kicks in if SOCK_NONBLOCK is undefined. But that header includes
include/compat/sys/socket.h, which also has a portability shim that
defines a default value for SOCK_NONBLOCK if it's undefined. Thus the
first portability shim was unreachable.

Fixes this by moving the NEED_SOCKET_FLAGS flag into the outer shim, and
having the inner shim activate if NEED_SOCKET_FLAGS is defined.

This closes https://github.com/libressl-portable/portable/issues/631