### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -6,7 +6,7 @@ jobs:
   build-native:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-12, macos-11]
         compiler: [clang, gcc]
     runs-on: ${{ matrix.os }}
     continue-on-error: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,26 @@
 image:
-  - Previous Visual Studio 2019
+  - Visual Studio 2019
 
 environment:
   PATH: C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\System32;C:\Windows;%PATH%
 
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
       ARCHITECTURE: Win32
       CONFIG: Release
       SHARED_LIBS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
       ARCHITECTURE: Win32
       CONFIG: Release
       SHARED_LIBS: OFF
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
       ARCHITECTURE: x64
       CONFIG: Release
       SHARED_LIBS: ON
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Visual Studio 2019
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
       ARCHITECTURE: x64
       CONFIG: Release

--- a/scripts/test
+++ b/scripts/test
@@ -20,24 +20,24 @@ if [ "x$ARCH" = "xnative" ]; then
 	# test cmake and ninja
 	if [ `uname` = "Darwin" ]; then
 		cmake ..
-		make
+		make -j 4
 		make test
 
 		cd ../build-shared
 		cmake -DBUILD_SHARED_LIBS=ON ..
-		make
+		make -j 4
 		make test
 	else
 		sudo apt-get update
 		sudo apt-get install -y cmake ninja-build
 
 		cmake -GNinja ..
-		ninja
+		ninja -j 4
 		ninja test
 
 		cd ../build-shared
 		cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
-		ninja
+		ninja -j 4
 		ninja test
 	fi
 
@@ -58,21 +58,21 @@ elif [ "x$ARCH" = "xmingw32" -o "x$ARCH" = "xmingw64" ]; then
 	fi
 
 	./configure --host=$CPU-w64-mingw32
-	make -j
+	make -j 4
 
 	(
 	 rm -fr build-static
 	 mkdir build-static
 	 cd build-static
 	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake ..
-	 ninja
+	 ninja -j 4
 	)
 	(
 	 rm -fr build-shared
 	 mkdir build-shared
 	 cd build-shared
 	 cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../scripts/$CPU-w64-mingw32.cmake -DBUILD_SHARED_LIBS=ON ..
-	 ninja
+	 ninja -j 4
 	)
 
 elif [ "x$ARCH" = "xarm32" -o "x$ARCH" = "xarm64" ]; then


### PR DESCRIPTION
- Add environment macos-12 to CI
- Set max number of processes for CI
- Use current VS2019 with appveyor

I also tried to add Android 12(API level 31), but it was not available still.