### PR TITLE
Stop disabling __attribute__ on Windows with Clang

### DIFF
--- a/patches/windows_headers.patch
+++ b/patches/windows_headers.patch
@@ -19,7 +19,7 @@ diff -u include/openssl.orig/dtls1.h include/openssl/dtls1.h
  #include <openssl/opensslfeatures.h>
  /* crypto/opensslconf.h.in */
 
-+#if defined(_MSC_VER) && !defined(__attribute__)
++#if defined(_MSC_VER) && !defined(__clang__) && !defined(__attribute__)
 +#define __attribute__(a)
 +#endif
 +


### PR DESCRIPTION
Experimental PR for talking about #734 .
I would like to see if this does not any harm for a while.

On Windows with targeting the MSVC ABI, Clang will define _MSC_VER,
and does not treat __attribute__ as a macro.
Clang's builtin headers (e.g. immintrin.h) use __attribute__ liberally,
and do not expect it to be ifdef-ed away.

Suggested from Nicholas Hutchinson by github issue.