### PR TITLE
tests: Fix the build with --disable-static

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,9 +12,9 @@ AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl
 AM_CPPFLAGS += -I $(top_srcdir)/apps/openssl/compat
 AM_CPPFLAGS += -D_PATH_SSL_CA_FILE=\"$(top_srcdir)/cert.pem\"
 
-LDADD = $(abs_top_builddir)/tls/.libs/libtls.a
-LDADD += $(abs_top_builddir)/ssl/.libs/libssl.a
-LDADD += $(abs_top_builddir)/crypto/.libs/libcrypto.a
+LDADD = $(abs_top_builddir)/tls/libtls_convenience.la
+LDADD += $(abs_top_builddir)/ssl/libssl.la
+LDADD += $(abs_top_builddir)/crypto/libcrypto.la
 LDADD += $(PLATFORM_LDADD) $(PROG_LDADD)
 if HOST_ASM_MACOSX_X86_64
 LDADD += $(abs_top_builddir)/crypto/.libs/libcrypto_la-cpuid-macosx-x86_64.o

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -3,42 +3,48 @@ include $(top_srcdir)/Makefile.am.common
 -include $(abs_top_builddir)/crypto/libcrypto_la_objects.mk
 -include $(abs_top_builddir)/ssl/libssl_la_objects.mk
 
+noinst_LTLIBRARIES = libtls_convenience.la
+
 lib_LTLIBRARIES = libtls.la
 
 EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 EXTRA_DIST += tls.sym
 
-libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym
-libtls_la_LIBADD = $(libcrypto_la_objects)
-libtls_la_LIBADD += $(libcompat_la_objects)
-libtls_la_LIBADD += $(libcompatnoopt_la_objects)
-libtls_la_LIBADD += $(libssl_la_objects)
-libtls_la_LIBADD += $(PLATFORM_LDADD)
-
-libtls_la_CPPFLAGS = $(AM_CPPFLAGS)
 if OPENSSLDIR_DEFINED
-libtls_la_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
+AM_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"@OPENSSLDIR@/cert.pem\"
 else
-libtls_la_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
+AM_CPPFLAGS += -DTLS_DEFAULT_CA_FILE=\"$(sysconfdir)/ssl/cert.pem\"
 endif
 
+libtls_la_LDFLAGS = -version-info @LIBTLS_VERSION@ -no-undefined -export-symbols $(top_srcdir)/tls/tls.sym
+libtls_la_LIBADD = libtls_convenience.la
+
 libtls_la_SOURCES = tls.c
-libtls_la_SOURCES += tls_client.c
-libtls_la_SOURCES += tls_bio_cb.c
-libtls_la_SOURCES += tls_config.c
-libtls_la_SOURCES += tls_conninfo.c
-libtls_la_SOURCES += tls_keypair.c
-libtls_la_SOURCES += tls_server.c
-libtls_la_SOURCES += tls_signer.c
-libtls_la_SOURCES += tls_ocsp.c
-libtls_la_SOURCES += tls_peer.c
-libtls_la_SOURCES += tls_util.c
-libtls_la_SOURCES += tls_verify.c
+
+libtls_convenience_la_LIBADD = $(libcrypto_la_objects)
+libtls_convenience_la_LIBADD += $(libcompat_la_objects)
+libtls_convenience_la_LIBADD += $(libcompatnoopt_la_objects)
+libtls_convenience_la_LIBADD += $(libssl_la_objects)
+libtls_convenience_la_LIBADD += $(PLATFORM_LDADD)
+
+
+libtls_convenience_la_SOURCES = tls_bio_cb.c
+libtls_convenience_la_SOURCES += tls_client.c
+libtls_convenience_la_SOURCES += tls_config.c
+libtls_convenience_la_SOURCES += tls_conninfo.c
+libtls_convenience_la_SOURCES += tls_init.c
+libtls_convenience_la_SOURCES += tls_keypair.c
+libtls_convenience_la_SOURCES += tls_server.c
+libtls_convenience_la_SOURCES += tls_signer.c
+libtls_convenience_la_SOURCES += tls_ocsp.c
+libtls_convenience_la_SOURCES += tls_peer.c
+libtls_convenience_la_SOURCES += tls_util.c
+libtls_convenience_la_SOURCES += tls_verify.c
 noinst_HEADERS = tls_internal.h
 
 if HOST_WIN
-libtls_la_SOURCES += compat/ftruncate.c
-libtls_la_SOURCES += compat/pread.c
-libtls_la_SOURCES += compat/pwrite.c
+libtls_convenience_la_SOURCES += compat/ftruncate.c
+libtls_convenience_la_SOURCES += compat/pread.c
+libtls_convenience_la_SOURCES += compat/pwrite.c
 endif


### PR DESCRIPTION
NOTE: This PR depends on PR https://github.com/libressl-portable/openbsd/pull/132 being merged first.

The tests require `--enable-static` because `-export-symbols` is set in `libtls_la_LDFLAGS` which hides many of the internal symbols for the shared library.

This can be avoided by compiling most of the code into a convenience library which the tests and libtls can both link against. The installed shared library will still use `-export-symbols` as expected without conflicting with the tests that require access to internal symbols.

Fixes https://github.com/libressl-portable/portable/issues/754