### PR TITLE
Detect machine/endian.h for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,11 @@ if(HAVE_ENDIAN_H)
 	add_definitions(-DHAVE_ENDIAN_H)
 endif()
 
+check_include_files(machine/endian.h HAVE_MACHINE_ENDIAN_H)
+if(HAVE_MACHINE_ENDIAN_H)
+	add_definitions(-DHAVE_MACHINE_ENDIAN_H)
+endif()
+
 check_include_files(err.h HAVE_ERR_H)
 if(HAVE_ERR_H)
 	add_definitions(-DHAVE_ERR_H)

--- a/include/compat/endian.h
+++ b/include/compat/endian.h
@@ -24,6 +24,9 @@
 #elif defined(HAVE_ENDIAN_H)
 #include_next <endian.h>
 
+#elif defined(HAVE_MACHINE_ENDIAN_H)
+#include_next <machine/endian.h>
+
 #elif defined(__sun) || defined(_AIX) || defined(__hpux)
 #include <sys/types.h>
 #include <arpa/nameser_compat.h>

--- a/m4/check-libc.m4
+++ b/m4/check-libc.m4
@@ -1,6 +1,6 @@
 AC_DEFUN([CHECK_LIBC_COMPAT], [
 # Check for libc headers
-AC_CHECK_HEADERS([endian.h err.h readpassphrase.h])
+AC_CHECK_HEADERS([endian.h machine/endian.h err.h readpassphrase.h])
 AC_CHECK_HEADERS([netinet/ip.h], [], [],
 [#include <sys/types.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
This pr fixes issue #749 by detecting `machine/endian.h` and trying to include it in `include/compat/endian.h`.