### PR TITLE
add direct source dependency to each library

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1009,7 +1009,7 @@ target_include_directories(crypto_obj
 	PUBLIC
 		../include)
 
-add_library(crypto $<TARGET_OBJECTS:crypto_obj>)
+add_library(crypto $<TARGET_OBJECTS:crypto_obj> empty.c)
 
 export_symbol(crypto ${CMAKE_CURRENT_BINARY_DIR}/crypto_p.sym)
 target_link_libraries(crypto ${PLATFORM_LIBS})

--- a/crypto/Makefile.am
+++ b/crypto/Makefile.am
@@ -32,6 +32,7 @@ endif
 EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 EXTRA_DIST += crypto.sym
+EXTRA_DIST += empty.c
 
 # needed for a CMake target
 EXTRA_DIST += compat/strcasecmp.c

--- a/ssl/CMakeLists.txt
+++ b/ssl/CMakeLists.txt
@@ -79,7 +79,7 @@ target_include_directories(bs_obj
 if(BUILD_SHARED_LIBS)
 	add_library(ssl $<TARGET_OBJECTS:ssl_obj> $<TARGET_OBJECTS:bs_obj>)
 else()
-	add_library(ssl $<TARGET_OBJECTS:ssl_obj>)
+	add_library(ssl $<TARGET_OBJECTS:ssl_obj> empty.c)
 endif()
 
 export_symbol(ssl ${CMAKE_CURRENT_SOURCE_DIR}/ssl.sym)

--- a/ssl/Makefile.am
+++ b/ssl/Makefile.am
@@ -15,6 +15,7 @@ noinst_DATA = remove_bs_objects
 EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 EXTRA_DIST += ssl.sym
+EXTRA_DIST += empty.c
 
 CLEANFILES = libssl_la_objects.mk
 

--- a/tls/CMakeLists.txt
+++ b/tls/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(tls_obj
 		../include)
 
 add_library(tls $<TARGET_OBJECTS:tls_obj> $<TARGET_OBJECTS:ssl_obj>
-	$<TARGET_OBJECTS:crypto_obj>)
+	$<TARGET_OBJECTS:crypto_obj> empty.c)
 
 export_symbol(tls ${CMAKE_CURRENT_BINARY_DIR}/tls.sym)
 target_link_libraries(tls ${PLATFORM_LIBS})

--- a/tls/Makefile.am
+++ b/tls/Makefile.am
@@ -8,6 +8,7 @@ lib_LTLIBRARIES = libtls.la
 EXTRA_DIST = VERSION
 EXTRA_DIST += CMakeLists.txt
 EXTRA_DIST += tls.sym
+EXTRA_DIST += empty.c
 
 CLEANFILES = libtls_la_objects.mk
 

--- a/update.sh
+++ b/update.sh
@@ -141,6 +141,7 @@ echo "LibreSSL version `cat VERSION`"
 # copy libcrypto source
 echo copying libcrypto source
 rm -f crypto/*.c crypto/*.h
+touch crypto/empty.c
 for i in `awk '/SOURCES|HEADERS/ { print $3 }' crypto/Makefile.am` ; do
 	dir=`dirname $i`
 	mkdir -p crypto/$dir
@@ -231,6 +232,7 @@ done
 # copy libtls source
 echo copying libtls source
 rm -f tls/*.c tls/*.h libtls/src/*.c libtls/src/*.h
+touch tls/empty.c
 for i in `awk '/SOURCES|HEADERS/ { print $3 }' tls/Makefile.am` ; do
 	if [ -e $libtls_src/$i ]; then
 		$CP $libtls_src/$i tls
@@ -276,6 +278,7 @@ done
 # copy libssl source
 echo "copying libssl source"
 rm -f ssl/*.c ssl/*.h
+touch ssl/empty.c
 for i in `awk '/SOURCES|HEADERS/ { print $3 }' ssl/Makefile.am` ; do
 	dir=`dirname $i`
 	mkdir -p ssl/$dir


### PR DESCRIPTION
Fix library generation with some CMake generators by including a direct source file dependency for each library. This is a small variation on #776 that includes libtls